### PR TITLE
CVS-166787 - Get latest status metadata after uploading media

### DIFF
--- a/web_ui/src/pages/project-details/components/project-media/training-notification/anomaly-projects-notification.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-media/training-notification/anomaly-projects-notification.component.tsx
@@ -32,7 +32,7 @@ export const AnomalyProjectsNotification = () => {
                 addNotification({
                     message: 'Training has started',
                     type: NOTIFICATION_TYPE.DEFAULT,
-                    dismiss: { duration: 0 }, //0 will act as infinite duration
+                    dismiss: { duration: 0 }, // We dont want the notification to be dismissed automatically
                     actionButtons: [
                         <QuietToggleButton
                             key={'open-train-model'}

--- a/web_ui/src/pages/project-details/components/project-media/training-notification/use-show-start-training.hook.test.tsx
+++ b/web_ui/src/pages/project-details/components/project-media/training-notification/use-show-start-training.hook.test.tsx
@@ -265,6 +265,7 @@ describe('useShowStartTraining', () => {
                 queryKey: QUERY_KEYS.PROJECT_STATUS_KEY({
                     workspaceId: 'workspace-id',
                     projectId: 'project-id',
+                    organizationId: '',
                 }),
             });
         });


### PR DESCRIPTION
## 📝 Description

On anomaly projects, after uploading media and showing the "Train model" notification, we did not have the latest project status metadata, which means when the user pressed "Train model" we assumed the model is not ready to be trained, so we triggered the `NotEnoughAnnotationsDialog`. This happened because we were not polling /status (intended) so we need be explicit on when we need it.

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
