### PR TITLE
CVS-166789 Move `ProjectsImportProvider` into `AppProviders`

### DIFF
--- a/web_ui/src/routes/app-routes.component.tsx
+++ b/web_ui/src/routes/app-routes.component.tsx
@@ -114,9 +114,11 @@ const AppProviders = (): JSX.Element => {
                         <LastLoginNotification />
                         <TusUploadProvider>
                             <MediaUploadProvider>
-                                <Outlet />
-                                {FEATURE_FLAG_CREDIT_SYSTEM && isSaaS && <WelcomeTrialModal />}
-                                {!isSaaS && <LicenseModal />}
+                                <ProjectsImportProvider>
+                                    <Outlet />
+                                    {FEATURE_FLAG_CREDIT_SYSTEM && isSaaS && <WelcomeTrialModal />}
+                                    {!isSaaS && <LicenseModal />}
+                                </ProjectsImportProvider>
                             </MediaUploadProvider>
                         </TusUploadProvider>
                     </OrganizationsContext>
@@ -263,14 +265,7 @@ export const appRoutes = () => {
 
                     {/* Landing page */}
                     <Route path={paths.root.pattern} element={<LandingPageLayout />}>
-                        <Route
-                            path={paths.workspace.pattern}
-                            element={
-                                <ProjectsImportProvider>
-                                    <IndexRoute />
-                                </ProjectsImportProvider>
-                            }
-                        />
+                        <Route path={paths.workspace.pattern} element={<IndexRoute />} />
                         <Route path={paths.account.index.pattern}>
                             <Route element={<RedirectToUsersProfile />} index />
                             <Route path={paths.account.profile.pattern} element={<UserManagementRoute />} />


### PR DESCRIPTION
## 📝 Description

By not having the provier in `AppProviders` we will reset its state whenever the user moves outo f the index route, which triggers the "Importing has been interrupted" message.

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
