### PR TITLE
CVS-166990 Don't show unavailble dataset formats when exporting

### DIFF
--- a/web_ui/src/pages/project-details/components/project-dataset/export-dataset/export-dataset-dialog.test.tsx
+++ b/web_ui/src/pages/project-details/components/project-dataset/export-dataset/export-dataset-dialog.test.tsx
@@ -135,63 +135,72 @@ describe('ExportDatasetDialog', () => {
             await renderApp({ domains: [DOMAIN.DETECTION_ROTATED_BOUNDING_BOX] });
             expect(queryRadioOption(ExportFormats.VOC)).toBeEnabled();
             expect(queryRadioOption(ExportFormats.COCO)).toBeEnabled();
-            expect(queryRadioOption(ExportFormats.YOLO)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.YOLO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
         });
 
         it('segmentation semantic', async () => {
             await renderApp({ domains: [DOMAIN.SEGMENTATION] });
             expect(queryRadioOption(ExportFormats.VOC)).toBeEnabled();
             expect(queryRadioOption(ExportFormats.COCO)).toBeEnabled();
-            expect(queryRadioOption(ExportFormats.YOLO)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.YOLO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
         });
 
         it('segmentation instance', async () => {
             await renderApp({ domains: [DOMAIN.SEGMENTATION_INSTANCE] });
             expect(queryRadioOption(ExportFormats.VOC)).toBeEnabled();
             expect(queryRadioOption(ExportFormats.COCO)).toBeEnabled();
-            expect(queryRadioOption(ExportFormats.YOLO)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.YOLO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
         });
 
         it('classification', async () => {
             await renderApp({ domains: [DOMAIN.CLASSIFICATION] });
             expect(queryRadioOption(ExportFormats.VOC)).toBeEnabled();
-            expect(queryRadioOption(ExportFormats.COCO)).toBeDisabled();
-            expect(queryRadioOption(ExportFormats.YOLO)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.COCO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.YOLO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
         });
 
         it('anomaly classification', async () => {
             await renderApp({ domains: [DOMAIN.ANOMALY_CLASSIFICATION] });
-            expect(queryRadioOption(ExportFormats.VOC)).toBeDisabled();
-            expect(queryRadioOption(ExportFormats.COCO)).toBeDisabled();
-            expect(queryRadioOption(ExportFormats.YOLO)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.VOC)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.COCO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.YOLO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
         });
 
         it('anomaly detection', async () => {
             await renderApp({ domains: [DOMAIN.ANOMALY_DETECTION] });
-            expect(queryRadioOption(ExportFormats.VOC)).toBeDisabled();
-            expect(queryRadioOption(ExportFormats.COCO)).toBeDisabled();
-            expect(queryRadioOption(ExportFormats.YOLO)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.VOC)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.COCO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.YOLO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
         });
 
         it('anomaly segmentation', async () => {
             await renderApp({ domains: [DOMAIN.ANOMALY_SEGMENTATION] });
-            expect(queryRadioOption(ExportFormats.VOC)).toBeDisabled();
-            expect(queryRadioOption(ExportFormats.COCO)).toBeDisabled();
-            expect(queryRadioOption(ExportFormats.YOLO)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.VOC)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.COCO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.YOLO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
         });
 
         it('detection classification', async () => {
             await renderApp({ domains: [DOMAIN.DETECTION, DOMAIN.CROP, DOMAIN.CLASSIFICATION] });
             expect(queryRadioOption(ExportFormats.VOC)).toBeEnabled();
-            expect(queryRadioOption(ExportFormats.COCO)).toBeDisabled();
-            expect(queryRadioOption(ExportFormats.YOLO)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.COCO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.YOLO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
         });
 
         it('detection segmentation', async () => {
             await renderApp({ domains: [DOMAIN.DETECTION, DOMAIN.CROP, DOMAIN.SEGMENTATION] });
             expect(queryRadioOption(ExportFormats.VOC)).toBeEnabled();
             expect(queryRadioOption(ExportFormats.COCO)).toBeEnabled();
-            expect(queryRadioOption(ExportFormats.YOLO)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.YOLO)).not.toBeInTheDocument();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
         });
 
         it.each([
@@ -205,16 +214,35 @@ describe('ExportDatasetDialog', () => {
             DOMAIN.SEGMENTATION_INSTANCE,
         ])('should render Datumaro export option when project domain is "%s"', async (domain) => {
             await renderApp({ domains: [domain] });
-            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeVisible();
         });
 
         it('should render Datumaro export option for task chain projects', async () => {
             await renderApp({ domains: [DOMAIN.DETECTION], isTaskChainProject: true });
 
+            expect(queryRadioOption(ExportFormats.VOC)).toBeVisible();
+            expect(queryRadioOption(ExportFormats.COCO)).toBeVisible();
+            expect(queryRadioOption(ExportFormats.YOLO)).toBeVisible();
+
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
+        });
+
+        it('disables all formats except datumaro when using native video export', async () => {
+            await renderApp({ domains: [DOMAIN.DETECTION], isTaskChainProject: true });
+
+            // Confirm that our default dataset contains videos
+            expect(await screen.findByText('2 frames', { exact: false })).toBeVisible();
+
             expect(queryRadioOption(ExportFormats.VOC)).toBeEnabled();
             expect(queryRadioOption(ExportFormats.COCO)).toBeEnabled();
             expect(queryRadioOption(ExportFormats.YOLO)).toBeEnabled();
+            expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
 
+            fireEvent.click(screen.getByRole('radio', { name: `Keep the native video format` }));
+
+            expect(queryRadioOption(ExportFormats.VOC)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.COCO)).toBeDisabled();
+            expect(queryRadioOption(ExportFormats.YOLO)).toBeDisabled();
             expect(queryRadioOption(ExportFormats.DATUMARO)).toBeEnabled();
         });
     });


### PR DESCRIPTION
## 📝 Description

Before we would show all dataset formats when exporting for instance an anomaly project. This leads to some confusion as it gives the impression to a user that they might be able to change a setting that could enable the export.

JIRA: CVS-166990

New options:
![localhost_3000_callback_code=hmhwablczv7wiwvrda2bjwyck state=9ab5bc1aeff040e4994c62562634c094](https://github.com/user-attachments/assets/d9a482e4-9fa3-4f4f-8090-f454e7202fe9)

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [x] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
