### PR TITLE
CVS-167022 Fix: show "Go to analytics" based on product info

### DIFF
--- a/web_ui/src/core/feature-flags/services/feature-flag-service.interface.ts
+++ b/web_ui/src/core/feature-flags/services/feature-flag-service.interface.ts
@@ -36,12 +36,6 @@ export const DEV_FEATURE_FLAGS = {
     FEATURE_FLAG_REQ_ACCESS: false,
     FEATURE_FLAG_TRAINING_FLOW_REVAMP: false,
 
-    // Grafana: User has a choice: either to install platform with grafana stack or no, if platform has grafana stack
-    // installed, we want to display button that redirects user to grafana page.
-    // TODO: I (@Dawid) proposed platform team to expose a new endpoint for flags that can be declared while platform
-    // installation, once they do it we can remove IS_GRAFANA_ENABLED from the feature flags.
-    IS_GRAFANA_ENABLED: true,
-
     // Only used for unit testing
     DEBUG: false,
 };

--- a/web_ui/src/pages/analytics/analytics.component.tsx
+++ b/web_ui/src/pages/analytics/analytics.component.tsx
@@ -7,7 +7,7 @@ import { View } from '@adobe/react-spectrum';
 import { AnimatePresence, motion } from 'framer-motion';
 
 import { DatabaseIcon, LogsIcon, MetricsIcon, TracesIcon } from '../../assets/icons';
-import { useFeatureFlags } from '../../core/feature-flags/hooks/use-feature-flags.hook';
+import { usePlatformUtils } from '../../core/platform-utils/hooks/use-platform-utils.hook';
 import { useApplicationServices } from '../../core/services/application-services-provider.component';
 import { ANIMATION_PARAMETERS } from '../../shared/animation-parameters/animation-parameters';
 import { AnalyticsDashboardCard } from './analytics-dashboard-card.component';
@@ -16,7 +16,9 @@ import { ExportAnalyticsType } from './export-logs.component';
 
 export const Analytics = (): JSX.Element => {
     const { router } = useApplicationServices();
-    const { IS_GRAFANA_ENABLED } = useFeatureFlags();
+    const { useProductInfo } = usePlatformUtils();
+    const productInfo = useProductInfo();
+    const IS_GRAFANA_ENABLED = productInfo.data?.grafanaEnabled;
 
     const ITEMS: ComponentProps<typeof DownloadableItem>[] = useMemo(() => {
         return [

--- a/web_ui/src/pages/analytics/analytics.component.tsx
+++ b/web_ui/src/pages/analytics/analytics.component.tsx
@@ -18,7 +18,7 @@ export const Analytics = (): JSX.Element => {
     const { router } = useApplicationServices();
     const { useProductInfo } = usePlatformUtils();
     const productInfo = useProductInfo();
-    const IS_GRAFANA_ENABLED = productInfo.data?.grafanaEnabled;
+    const isGrafanaEnabled = productInfo.data?.grafanaEnabled;
 
     const ITEMS: ComponentProps<typeof DownloadableItem>[] = useMemo(() => {
         return [
@@ -56,7 +56,7 @@ export const Analytics = (): JSX.Element => {
 
     return (
         <View>
-            {IS_GRAFANA_ENABLED && <AnalyticsDashboardCard />}
+            {isGrafanaEnabled && <AnalyticsDashboardCard />}
             <View marginStart={'size-75'} width={'size-6000'}>
                 <AnimatePresence>
                     {ITEMS.map((item, index) => (

--- a/web_ui/src/pages/analytics/analytics.test.tsx
+++ b/web_ui/src/pages/analytics/analytics.test.tsx
@@ -3,6 +3,8 @@
 
 import { fireEvent, screen } from '@testing-library/react';
 
+import { Environment, GPUProvider } from '../../core/platform-utils/dto/utils.interface';
+import { createInMemoryPlatformUtilsService } from '../../core/platform-utils/services/create-in-memory-platform-utils-service';
 import { providersRender as render } from '../../test-utils/required-providers-render';
 import { Analytics } from './analytics.component';
 import { ExportServerType } from './downloadable-item.component';
@@ -17,7 +19,20 @@ describe('Analytics', () => {
     const SERVER_ITEM = { header: ExportServerType.SERVER_INFO };
 
     it('should display card for external analytics dashboard', async () => {
-        render(<Analytics />, { featureFlags: { IS_GRAFANA_ENABLED: true } });
+        const platformUtilsService = createInMemoryPlatformUtilsService();
+        platformUtilsService.getProductInfo = async () => {
+            return {
+                productVersion: '1.6.0',
+                grafanaEnabled: true,
+                gpuProvider: GPUProvider.INTEL,
+                buildVersion: '1.6.0.test.123123',
+                isSmtpDefined: true,
+                intelEmail: 'support@geti.com',
+                environment: Environment.ON_PREM,
+            };
+        };
+
+        render(<Analytics />, { services: { platformUtilsService } });
 
         expect(await screen.findByRole('button', { name: /go to analytics/i })).toBeInTheDocument();
     });

--- a/web_ui/tests/features/profile-page/analytics.spec.ts
+++ b/web_ui/tests/features/profile-page/analytics.spec.ts
@@ -8,7 +8,20 @@ test.describe('Account page - analytics tab', () => {
     const accountAnalyticsUrl = ACCOUNT_URL('5b1f89f3-aba5-4a5f-84ab-de9abb8e0633', 'analytics');
     const tabs = ['metrics', 'traces', 'logs'];
 
-    test.beforeEach(async ({ page }) => {
+    test.beforeEach(async ({ page, registerApiResponse }) => {
+        registerApiResponse('GetProductInfo', (_, res, ctx) => {
+            return res(
+                ctx.json({
+                    'product-version': '2.9.0',
+                    'build-version': '2.9.0-test-20250428191218',
+                    'smtp-defined': 'True',
+                    'intel-email': 'Geti.Team@intel.com',
+                    grafana_enabled: true,
+                    environment: 'on-prem',
+                    'gpu-provider': 'intel',
+                })
+            );
+        });
         await page.goto(accountAnalyticsUrl);
     });
 


### PR DESCRIPTION
## 📝 Description

This PR fixes the UI no longer showing Grafana when it is enabled on the backend. Previously we were using a feature flag to check this, but I think this broke when we removed the feature flag provider.
We fix this by no longer relying on feature flags for this and instead using the `/api/v1/product_info` endpoint. This endpoint has a `grafana_enabled` field that we can rely on.

JIRA: CVS-167022


## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
