### PR TITLE
Render a react-router Link when adding href to a button

### DIFF
--- a/web_ui/src/shared/components/button/button.component.tsx
+++ b/web_ui/src/shared/components/button/button.component.tsx
@@ -3,7 +3,7 @@
 
 /* eslint-disable no-restricted-imports */
 
-import { forwardRef, Ref } from 'react';
+import { ComponentProps, forwardRef, Ref } from 'react';
 
 import {
     ActionButton as SpectrumActionButton,
@@ -12,6 +12,7 @@ import {
     SpectrumButtonProps,
 } from '@adobe/react-spectrum';
 import { FocusableRef, FocusableRefValue } from '@react-types/shared';
+import { Link } from 'react-router-dom';
 
 type VariantWithoutLegacyButtonVariant = Exclude<SpectrumButtonProps['variant'], 'cta' | 'overBackground'>;
 
@@ -20,12 +21,28 @@ export interface ButtonProps extends Omit<SpectrumButtonProps, 'variant'> {
     variant?: VariantWithoutLegacyButtonVariant;
 }
 
+// https://github.com/adobe/react-spectrum/blob/main/packages/%40react-aria/button/src/useButton.ts#L75
+// This component builds up a link with a fixed `to` prop,
+// this used so that it can be used as `elementTYpe={LinkBuilder(href)}` in a react/spectrum
+// button component, which does not forward an href for custom element types
+type LinkProps = ComponentProps<typeof Link>;
+function LinkBuilder({ href, target, rel }: { href: string; target?: LinkProps['target']; rel: LinkProps['rel'] }) {
+    return forwardRef((props: LinkProps, ref: LinkProps['ref']) => {
+        return <Link {...props} ref={ref} target={target} rel={rel} to={href} />;
+    });
+}
+
 export interface ActionButtonProps extends SpectrumActionButtonProps {
     ref?: Ref<FocusableRefValue<HTMLElement, HTMLButtonElement>>;
 }
 
 export const Button = forwardRef((props: ButtonProps, ref: ButtonProps['ref']) => {
-    return <SpectrumButton {...props} variant={props.variant ?? 'accent'} ref={ref} />;
+    const elementType =
+        props.href === undefined
+            ? props.elementType
+            : LinkBuilder({ href: props.href, target: props.target, rel: props.rel });
+
+    return <SpectrumButton {...props} elementType={elementType} variant={props.variant ?? 'accent'} ref={ref} />;
 });
 
 export const ActionButton = forwardRef((props: ActionButtonProps, ref: ActionButtonProps['ref']) => {

--- a/web_ui/src/shared/components/button/button.test.tsx
+++ b/web_ui/src/shared/components/button/button.test.tsx
@@ -1,0 +1,51 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter as Router, useLocation } from 'react-router-dom';
+
+import { ThemeProvider } from '../../../theme/theme-provider.component';
+import { Button } from './button.component';
+
+describe('Button', () => {
+    it('renders a button', async () => {
+        const onPress = jest.fn();
+        render(
+            <ThemeProvider>
+                <Router>
+                    <Button onPress={onPress}>Go to annotator</Button>
+                </Router>
+            </ThemeProvider>
+        );
+        const button = screen.getByRole('button');
+        expect(button).toBeInTheDocument();
+        fireEvent.click(button);
+        expect(onPress).toHaveBeenCalled();
+    });
+
+    it('renders a button as a link when a href is used', async () => {
+        const Pathname = () => {
+            const location = useLocation();
+
+            return <span aria-label='pathname'>{location.pathname}</span>;
+        };
+        const onPress = jest.fn();
+        render(
+            <ThemeProvider>
+                <Router>
+                    <Button href='/annotator' onPress={onPress}>
+                        Go to annotator
+                    </Button>
+                    <Pathname />
+                </Router>
+            </ThemeProvider>
+        );
+
+        const button = screen.getByRole('button');
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveAttribute('href', '/annotator');
+        fireEvent.click(button);
+        expect(onPress).toHaveBeenCalled();
+        expect(screen.getByLabelText('pathname')).toHaveTextContent('/annotator');
+    });
+});


### PR DESCRIPTION
## 📝 Description

This allows us to render buttons with `<Button href="/annotator" />`, which will look like a button, but have a link behaviour: users can middle-click or control click to open the link in a new tab or click the link to open it in the current page.

We also allow passing target and rel as these can be used for implementing download links.

Note that ideally we would simply render a `<Link to="/annotator">` however this would require us to copy over the button styles so that they work for links as well.
This likely is less maintainable as it could introduce regressions whenever we update `@adobe/react-spectrum`.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
