### PR TITLE
Fix that Auto-training Started Notification is triggered both by scheduled and running training jobs

### DIFF
--- a/web_ui/src/core/services/use-deployment-config-query.hook.test.tsx
+++ b/web_ui/src/core/services/use-deployment-config-query.hook.test.tsx
@@ -242,7 +242,7 @@ describe('useDeploymentConfigQuery', () => {
         });
 
         const data = result.current.data;
-        expect(data?.docsUrl).toEqual('https://docs.geti.intel.com/cloud/');
+        expect(data?.docsUrl).toEqual('https://docs.geti.intel.com/');
     });
 
     it('ignores the data and control plane urls', async () => {

--- a/web_ui/src/core/services/use-deployment-config-query.hook.ts
+++ b/web_ui/src/core/services/use-deployment-config-query.hook.ts
@@ -59,7 +59,7 @@ const deploymentConfigurationBasedOnFeatureFlags = (isAdmin: boolean): Deploymen
         },
         controlPlaneUrl: null,
         dataPlaneUrl: null,
-        docsUrl: 'https://docs.geti.intel.com/cloud/',
+        docsUrl: 'https://docs.geti.intel.com/',
         configUrl: null,
     };
 };
@@ -88,7 +88,7 @@ export const deploymentConfigQueryOptions = (isAdmin: boolean): UseSuspenseQuery
 
                 await deploymentSchema.validate(deployment.data);
 
-                let docsUrl = deployment.data.docsUrl ?? 'https://docs.geti.intel.com/cloud/';
+                let docsUrl = deployment.data.docsUrl ?? 'https://docs.geti.intel.com/';
 
                 if (!docsUrl.endsWith('/')) {
                     docsUrl += '/';

--- a/web_ui/src/hooks/use-is-saas-env/use-is-saas-env.hook.test.ts
+++ b/web_ui/src/hooks/use-is-saas-env/use-is-saas-env.hook.test.ts
@@ -37,7 +37,7 @@ describe('useIsSaasEnv', () => {
     it('returns true if environment is Saas', () => {
         jest.mocked(useDeploymentConfigQuery).mockReturnValue({
             // @ts-expect-error We only use data
-            data: { ...mockConfig, servingMode: 'saas', docsUrl: 'https://docs.geti.intel.com/cloud/' },
+            data: { ...mockConfig, servingMode: 'saas', docsUrl: 'https://docs.geti.intel.com/' },
         });
 
         const { result } = renderHook(() => useIsSaasEnv());

--- a/web_ui/src/pages/annotator/notification/auto-training-credits-modal/auto-training-credits-modal.component.tsx
+++ b/web_ui/src/pages/annotator/notification/auto-training-credits-modal/auto-training-credits-modal.component.tsx
@@ -23,7 +23,7 @@ import { CreditsToConsume } from '../../../../shared/components/header/credit-ba
 import { getFuxSetting } from '../../../../shared/components/tutorials/utils';
 import { useProject } from '../../../project-details/providers/project-provider/project-provider.component';
 import { useIsAutoTrainingOn } from '../../hooks/use-is-auto-training-on.hook';
-import { onFirstScheduledAutoTrainingJob } from './util';
+import { onFirstScheduledOrRunningAutoTrainingJob } from './util';
 
 import classes from './auto-training-credits-modal.module.scss';
 
@@ -96,7 +96,7 @@ export const AutoTrainingCreditsModal = ({ settings }: AutoTrainingCreditsModalP
     useAutoTrainingCreditsJobs({
         enabled: isQueryEnabled,
         projectIdentifier,
-        onSuccess: onFirstScheduledAutoTrainingJob(settings, (jobId: string) => {
+        onSuccess: onFirstScheduledOrRunningAutoTrainingJob(settings, (jobId: string) => {
             if (isQueryEnabled && !isOpen) {
                 setIsOpen(true);
                 handleDisplayModal(jobId);

--- a/web_ui/src/pages/annotator/notification/auto-training-credits-modal/auto-training-credits-modal.test.tsx
+++ b/web_ui/src/pages/annotator/notification/auto-training-credits-modal/auto-training-credits-modal.test.tsx
@@ -24,8 +24,9 @@ import { AutoTrainingCreditsModal } from './auto-training-credits-modal.componen
 
 jest.mock('./util', () => ({
     ...jest.requireActual('./util'),
-    onFirstScheduledAutoTrainingJob: (_settings: UseSettings<UserGlobalSettings>, callback: () => void) => () =>
-        callback(),
+    onFirstScheduledOrRunningAutoTrainingJob:
+        (_settings: UseSettings<UserGlobalSettings>, callback: () => void) => () =>
+            callback(),
 }));
 
 jest.mock(

--- a/web_ui/src/pages/annotator/notification/auto-training-credits-modal/util.test.ts
+++ b/web_ui/src/pages/annotator/notification/auto-training-credits-modal/util.test.ts
@@ -98,7 +98,10 @@ describe('auto-training-credits-modal utils', () => {
 
         it('no scheduled jobs', () => {
             jest.mocked(getFuxSetting).mockReturnValue(true);
-            onFirstScheduledOrRunningAutoTrainingJob(getMockedUserGlobalSettingsObject(), mockedCallback)(getJobResponse());
+            onFirstScheduledOrRunningAutoTrainingJob(
+                getMockedUserGlobalSettingsObject(),
+                mockedCallback
+            )(getJobResponse());
             expect(mockedCallback).toHaveBeenCalledTimes(0);
         });
 

--- a/web_ui/src/pages/annotator/notification/auto-training-credits-modal/util.ts
+++ b/web_ui/src/pages/annotator/notification/auto-training-credits-modal/util.ts
@@ -18,13 +18,16 @@ export const onFirstScheduledAutoTrainingJob =
 
         const { jobs, jobsCount } = pages[0];
         const totalScheduledJobs = Number(jobsCount.numberOfScheduledJobs);
-        const hasScheduleTrainingJobs = totalScheduledJobs > 0;
-        const neverAutotrained = getFuxSetting(FUX_SETTINGS_KEYS.NEVER_AUTOTRAINED, settings.config);
+        const totalRunningJobs = Number(jobsCount.numberOfRunningJobs);
+        const hasScheduledOrRunningTrainingJobs = totalScheduledJobs > 0 || totalRunningJobs > 0;
+        const neverAutoTrained = getFuxSetting(FUX_SETTINGS_KEYS.NEVER_AUTOTRAINED, settings.config);
         const isAutoTrainingJob = jobs.find((job) => {
-            return job.state === JobState.SCHEDULED && job.authorId === GETI_SYSTEM_AUTHOR_ID;
+            return (
+                (job.state === JobState.SCHEDULED || job.state === JobState.RUNNING) &&
+                job.authorId === GETI_SYSTEM_AUTHOR_ID
+            );
         });
-
-        if (hasScheduleTrainingJobs && neverAutotrained && isAutoTrainingJob) {
+        if (hasScheduledOrRunningTrainingJobs && neverAutoTrained && isAutoTrainingJob) {
             const jobId = isAutoTrainingJob.id;
             callback(jobId);
         }

--- a/web_ui/src/pages/annotator/notification/auto-training-credits-modal/util.ts
+++ b/web_ui/src/pages/annotator/notification/auto-training-credits-modal/util.ts
@@ -9,7 +9,7 @@ import { FUX_SETTINGS_KEYS } from '../../../../core/user-settings/dtos/user-sett
 import { UserGlobalSettings, UseSettings } from '../../../../core/user-settings/services/user-settings.interface';
 import { getFuxSetting } from '../../../../shared/components/tutorials/utils';
 
-export const onFirstScheduledAutoTrainingJob =
+export const onFirstScheduledOrRunningAutoTrainingJob =
     (settings: UseSettings<UserGlobalSettings>, callback: (jobId: string) => void) =>
     ({ pages }: InfiniteData<JobsResponse>) => {
         if (!pages[0]) {

--- a/web_ui/src/pages/annotator/tools/bounding-box/index.tsx
+++ b/web_ui/src/pages/annotator/tools/bounding-box/index.tsx
@@ -18,7 +18,7 @@ export const BoundingBoxTool: ToolProps = {
     SecondaryToolbar,
     tooltip: {
         img: DetectionImg,
-        url: 'guide/annotations/annotation-tools.html#bounding-box-tool',
+        url: 'docs/user-guide/geti-fundamentals/annotations/annotation-tools#bounding-box-tool',
         title: toolTypeToLabelMapping[ToolType.BoxTool],
         description: `The tool intended for object detection task. A bounding box is a rectangle surrounding
         an object in an image.`,

--- a/web_ui/src/pages/annotator/tools/circle-tool/index.tsx
+++ b/web_ui/src/pages/annotator/tools/circle-tool/index.tsx
@@ -19,7 +19,7 @@ export const CircleTool: ToolProps = {
     SecondaryToolbar,
     tooltip: {
         img: CircleImg,
-        url: 'guide/annotations/annotation-tools.html#circle-tool',
+        url: 'docs/user-guide/geti-fundamentals/annotations/annotation-tools#circle-tool',
         title: toolTypeToLabelMapping[ToolType.CircleTool],
         description: `Its purpose is to simplify annotation of circular objects.`,
     },

--- a/web_ui/src/pages/annotator/tools/grabcut-tool/index.tsx
+++ b/web_ui/src/pages/annotator/tools/grabcut-tool/index.tsx
@@ -19,7 +19,7 @@ export const GrabcutTool: ToolProps = {
     supportedDomains: [DOMAIN.SEGMENTATION, DOMAIN.SEGMENTATION_INSTANCE, DOMAIN.ANOMALY_SEGMENTATION],
     tooltip: {
         img: QuickSelectionImg,
-        url: 'guide/annotations/annotation-tools.html#quick-selection-tool',
+        url: 'docs/user-guide/geti-fundamentals/annotations/annotation-tools#object-selection-tool',
         title: toolTypeToLabelMapping[ToolType.GrabcutTool],
         description: `Simply draw a rectangle around the object and Intel® Geti™ will fit a 
             polygon to the shape of the object.`,

--- a/web_ui/src/pages/annotator/tools/polygon-tool/index.tsx
+++ b/web_ui/src/pages/annotator/tools/polygon-tool/index.tsx
@@ -19,7 +19,7 @@ export const PolygonTool: ToolProps = {
     SecondaryToolbar,
     tooltip: {
         img: PolygonImg,
-        url: 'guide/annotations/annotation-tools.html#polygon-tool',
+        url: 'docs/user-guide/geti-fundamentals/annotations/annotation-tools#polygon-tool',
         title: toolTypeToLabelMapping[ToolType.PolygonTool],
         description: `The polygon tool allows for free form drawing around shapes.`,
     },

--- a/web_ui/src/pages/annotator/tools/ritm-tool/index.tsx
+++ b/web_ui/src/pages/annotator/tools/ritm-tool/index.tsx
@@ -25,7 +25,7 @@ export const RITMTool: ToolProps = {
     ],
     tooltip: {
         img: RITMImg,
-        url: 'guide/annotations/annotation-tools.html#interactive-segmentation',
+        url: 'docs/user-guide/geti-fundamentals/annotations/annotation-tools#interactive-segmentation-tool',
         title: toolTypeToLabelMapping[ToolType.RITMTool],
         description: 'Left-click on an object to draw a polygon around it.',
     },

--- a/web_ui/src/pages/annotator/tools/rotated-bounding-box-tool/index.tsx
+++ b/web_ui/src/pages/annotator/tools/rotated-bounding-box-tool/index.tsx
@@ -19,7 +19,7 @@ export const RotatedBoundingBoxTool: ToolProps = {
     StateProvider: ({ children }) => <>{children}</>,
     tooltip: {
         img: RotatedDetectionImg,
-        url: 'guide/annotations/annotation-tools.html#bounding-box-tool',
+        url: 'docs/user-guide/geti-fundamentals/annotations/annotation-tools#bounding-box-tool',
         title: toolTypeToLabelMapping[ToolType.RotatedBoxTool],
         description: `The tool intended for object detection task.
          A rotated bounding box acts as a normal bounding box, but it can be rotated to fit the object better.`,

--- a/web_ui/src/pages/annotator/tools/segment-anything-tool/index.tsx
+++ b/web_ui/src/pages/annotator/tools/segment-anything-tool/index.tsx
@@ -27,7 +27,7 @@ export const SegmentAnythingTool: ToolProps = {
     ],
     tooltip: {
         img: RITMImg,
-        url: 'guide/annotations/annotation-tools.html#automatic-segmentation',
+        url: 'docs/user-guide/geti-fundamentals/annotations/annotation-tools#automatic-segmentation-tool',
         title: toolTypeToLabelMapping[ToolType.SegmentAnythingTool],
         description: 'Click on an object to draw a shape around it. Shift-click to subtract or add parts.',
     },

--- a/web_ui/src/pages/annotator/tools/ssim-tool/index.tsx
+++ b/web_ui/src/pages/annotator/tools/ssim-tool/index.tsx
@@ -20,7 +20,7 @@ export const SSIMTool: ToolProps = {
     supportedDomains: SSIM_SUPPORTED_DOMAINS,
     tooltip: {
         img: SSIMImg,
-        url: 'guide/annotations/annotation-tools.html#detection-assistant',
+        url: 'docs/user-guide/geti-fundamentals/annotations/annotation-tools#detection-assistant-tool',
         title: toolTypeToLabelMapping[ToolType.SSIMTool],
         description:
             'Draw a box or a circle over an object and the system will mark all objects similar to the ' +

--- a/web_ui/src/pages/annotator/tools/watershed-tool/index.tsx
+++ b/web_ui/src/pages/annotator/tools/watershed-tool/index.tsx
@@ -18,7 +18,7 @@ export const WatershedTool: ToolProps = {
     Tool,
     tooltip: {
         img: ObjectColoringImg,
-        url: 'guide/annotations/annotation-tools.html#object-coloring-tool',
+        url: 'docs/user-guide/geti-fundamentals/annotations/annotation-tools#object-coloring-tool',
         title: toolTypeToLabelMapping[ToolType.WatershedTool],
         description: 'Simply select the brush and draw over the objects you want to annotate.',
     },

--- a/web_ui/src/pages/create-project/import-project-panel.component.tsx
+++ b/web_ui/src/pages/create-project/import-project-panel.component.tsx
@@ -36,7 +36,7 @@ export const ProjectImportPanel = ({
 
     const fileInputRef = useRef<HTMLInputElement>({} as HTMLInputElement);
     const isExtraLarge = useMediaQuery(isExtraLargeSizeQuery);
-    const projectImportDocsUrl = `${docsUrl}/guide/project-management/project-management.html#export-import-project'`;
+    const projectImportDocsUrl = `${docsUrl}docs/user-guide/geti-fundamentals/project-management/project-export-import`;
 
     const handleDropProject = (file?: File) => {
         if (file && !isValidFileExtension(file, VALID_EXTENSIONS)) {

--- a/web_ui/src/shared/components/coach-mark/fux-notifications/auto-training-coach-mark.component.tsx
+++ b/web_ui/src/shared/components/coach-mark/fux-notifications/auto-training-coach-mark.component.tsx
@@ -14,7 +14,7 @@ import { FUX_NOTIFICATION_KEYS, FUX_SETTINGS_KEYS } from '../../../../core/user-
 import { useUserGlobalSettings } from '../../../../core/user-settings/hooks/use-global-settings.hook';
 import { useFuxNotifications } from '../../../../hooks/use-fux-notifications/use-fux-notifications.hook';
 import { useIsAutoTrainingOn } from '../../../../pages/annotator/hooks/use-is-auto-training-on.hook';
-import { onFirstScheduledAutoTrainingJob } from '../../../../pages/annotator/notification/auto-training-credits-modal/util';
+import { onFirstScheduledOrRunningAutoTrainingJob } from '../../../../pages/annotator/notification/auto-training-credits-modal/util';
 import { useProject } from '../../../../pages/project-details/providers/project-provider/project-provider.component';
 import { getFuxSetting } from '../../tutorials/utils';
 import { CoachMark } from '../coach-mark.component';
@@ -32,7 +32,7 @@ const useAutoTrainingCoachMarkJobs = () => {
 
     const handleSuccess = useCallback(
         (jobs: InfiniteData<JobsResponse>) =>
-            onFirstScheduledAutoTrainingJob(settings, (jobId: string) => {
+            onFirstScheduledOrRunningAutoTrainingJob(settings, (jobId: string) => {
                 if (isQueryEnabled) {
                     handleFirstAutoTraining(project.id, jobId);
                 }

--- a/web_ui/src/shared/components/tutorial-card/tutorial-card.component.test.tsx
+++ b/web_ui/src/shared/components/tutorial-card/tutorial-card.component.test.tsx
@@ -86,7 +86,7 @@ describe('TutorialCard', () => {
 
         fireEvent.click(learnMoreBtn);
         expect(onPressLearnMoreMock).toHaveBeenCalledWith(
-            'https://docs.geti.intel.com/user-guide/learn-geti/active-learning'
+            'https://docs.geti.intel.com/docs/user-guide/learn-geti/active-learning'
         );
     });
 

--- a/web_ui/src/shared/components/tutorials/utils.ts
+++ b/web_ui/src/shared/components/tutorials/utils.ts
@@ -90,24 +90,24 @@ export const dismissAllTutorials = async (settings: UseSettings<UserGlobalSettin
 };
 
 export enum DocsUrl {
-    LABELS_CREATION = 'user-guide/geti-fundamentals/project-management#labels-creation',
-    DETECTION = 'user-guide/geti-fundamentals/project-management#labels-creation',
-    CLASSIFICATION = 'user-guide/geti-fundamentals/project-management#labels-creation',
-    SEGMENTATION = 'user-guide/geti-fundamentals/project-management#labels-creation',
-    REVISIT_LABELS = 'user-guide/geti-fundamentals/labels/labels-management' +
+    LABELS_CREATION = 'docs/user-guide/geti-fundamentals/project-management#labels-creation',
+    DETECTION = 'docs/user-guide/geti-fundamentals/project-management#labels-creation',
+    CLASSIFICATION = 'docs/user-guide/geti-fundamentals/project-management#labels-creation',
+    SEGMENTATION = 'docs/user-guide/geti-fundamentals/project-management#labels-creation',
+    REVISIT_LABELS = 'docs/user-guide/geti-fundamentals/labels/labels-management' +
         '#dealing-with-new-labels-and-concept-drift-in-the-intel-geti-platform',
-    DATASET = 'user-guide/geti-fundamentals/datasets/dataset-management',
-    MODELS = 'user-guide/geti-fundamentals/model-training-and-optimization',
-    TESTS = 'user-guide/geti-fundamentals/tests-management/tests',
-    DEPLOYMENT = 'user-guide/geti-fundamentals/deployments/',
-    MAIN_PAGE = 'user-guide/getting-started/introduction',
-    ANNOTATIONS_VS_PREDICTIONS = 'user-guide/geti-fundamentals/annotations/annotation-editor' +
+    DATASET = 'docs/user-guide/geti-fundamentals/datasets/dataset-management',
+    MODELS = 'docs/user-guide/geti-fundamentals/model-training-and-optimization',
+    TESTS = 'docs/user-guide/geti-fundamentals/tests-management/tests',
+    DEPLOYMENT = 'docs/user-guide/geti-fundamentals/deployments/',
+    MAIN_PAGE = 'docs/user-guide/getting-started/introduction',
+    ANNOTATIONS_VS_PREDICTIONS = 'docs/user-guide/geti-fundamentals/annotations/annotation-editor' +
         '#annotations-vs-predictions',
-    ACTIVE_LEARNING = 'user-guide/learn-geti/active-learning',
-    MEDIA_GALLERY = 'user-guide/geti-fundamentals/annotations/annotation-mode#media-gallery',
-    ANNOTATION_TOOLS = 'user-guide/geti-fundamentals/annotations/annotation-tools',
-    ANNOTATION_EDITOR = 'user-guide/geti-fundamentals/annotations/annotation-editor',
-    CODE_DEPLOYMENT = 'user-guide/geti-fundamentals/deployments/code-deployment',
+    ACTIVE_LEARNING = 'docs/user-guide/learn-geti/active-learning',
+    MEDIA_GALLERY = 'docs/user-guide/geti-fundamentals/annotations/annotation-mode#media-gallery',
+    ANNOTATION_TOOLS = 'docs/user-guide/geti-fundamentals/annotations/annotation-tools',
+    ANNOTATION_EDITOR = 'docs/user-guide/geti-fundamentals/annotations/annotation-editor',
+    CODE_DEPLOYMENT = 'docs/user-guide/geti-fundamentals/deployments/code-deployment',
 }
 
 export const onPressLearnMore = (docUrl: string | undefined) => {

--- a/web_ui/tests/features/credit-system/mocks.ts
+++ b/web_ui/tests/features/credit-system/mocks.ts
@@ -39,6 +39,37 @@ export const getScheduledTrainingJob = (job = getMockedJob({ state: JobState.SCH
     },
 });
 
+export const getRunningAutoTrainingJob = (
+    job = getMockedJob({ state: JobState.RUNNING, author: GETI_SYSTEM_AUTHOR_ID })
+) => ({
+    jobs: [
+        {
+            ...job,
+            type: JobType.TRAIN,
+            metadata: {
+                project: {
+                    id: '662f70313090f9f2aa13b7ed',
+                    name: 'Candy',
+                },
+                task: {
+                    task_id: '662f70313090f9f2aa13b7f0',
+                    name: 'Detection',
+                    model_template_id: 'Custom_Object_Detection_Gen3_ATSS',
+                    model_architecture: 'MobileNetV2-ATSS',
+                    dataset_storage_id: '662f70313090f9f2aa13b7f4',
+                },
+            },
+        },
+    ],
+    jobs_count: {
+        n_scheduled_jobs: 1,
+        n_running_jobs: 0,
+        n_finished_jobs: 0,
+        n_failed_jobs: 0,
+        n_cancelled_jobs: 0,
+    },
+});
+
 export const getScheduledAutoTrainingJob = (
     job = getMockedJob({ state: JobState.SCHEDULED, author: GETI_SYSTEM_AUTHOR_ID })
 ) => ({

--- a/web_ui/tests/features/fux/annotator-training-fux.spec.ts
+++ b/web_ui/tests/features/fux/annotator-training-fux.spec.ts
@@ -11,6 +11,7 @@ import { registerStoreSettings } from '../../utils/api';
 import {
     getFinishedAutoTrainingJob,
     getFinishedTrainingJob,
+    getRunningAutoTrainingJob,
     getScheduledAutoTrainingCostJob,
     getScheduledAutoTrainingJob,
     getScheduledTrainingCostJob,
@@ -60,6 +61,30 @@ test.describe('Check FUX notifications in Annotator related to training', () => 
             await expect(page.getByText('Continue annotating')).toBeVisible();
 
             registerApiResponse('GetJobs', (_, res, ctx) => res(ctx.json(getScheduledAutoTrainingJob())));
+
+            await expect(page.getByText('Continue annotating')).toBeHidden();
+            await expect(page.getByText(autoTrainingNotificationRegex)).toBeVisible();
+        });
+
+        // eslint-disable-next-line max-len
+        test('With a running auto-training job, "Auto-training Notification" should appear and "Continue Annotating" notification should not be shown', async ({
+            page,
+            registerApiResponse,
+        }) => {
+            registerStoreSettings(registerApiResponse, {
+                [FUX_NOTIFICATION_KEYS.ANNOTATOR_CONTINUE_ANNOTATING]: {
+                    isEnabled: true,
+                },
+                [FUX_SETTINGS_KEYS.NEVER_ANNOTATED]: {
+                    value: false,
+                },
+            });
+
+            await goToAnnotatorInActiveMode(page);
+
+            await expect(page.getByText('Continue annotating')).toBeVisible();
+
+            registerApiResponse('GetJobs', (_, res, ctx) => res(ctx.json(getRunningAutoTrainingJob())));
 
             await expect(page.getByText('Continue annotating')).toBeHidden();
             await expect(page.getByText(autoTrainingNotificationRegex)).toBeVisible();


### PR DESCRIPTION
## 📝 Description

- The jobs changed state from scheduled to running so fast that the notification sometimes did not get displayed.
So for users that have never auto-trained any project the notification will be displayed both when the task is in the scheduled jobs and running jobs. It doesn't change the UX flow.
- updated links to documentation
- added tests

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [x] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
