### PR TITLE
fix: Close training dialog when user started training

### DIFF
--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
@@ -8,6 +8,7 @@ import { FC } from 'react';
 
 import { ButtonGroup, Content, Dialog, DialogContainer, Divider, Heading } from '@adobe/react-spectrum';
 import { Button } from '@geti/ui';
+import { isFunction } from 'lodash-es';
 
 import { useModels } from '../../../../../core/models/hooks/use-models.hook';
 import { useProjectIdentifier } from '../../../../../hooks/use-project-identifier/use-project-identifier';
@@ -61,7 +62,10 @@ const TrainModelDialog: FC<TrainModelDialogProps> = ({ onClose, onSuccess, isAll
         trainModel.mutate(
             { projectIdentifier, body: trainingBodyDTO },
             {
-                onSuccess,
+                onSuccess: () => {
+                    onClose();
+                    isFunction(onSuccess) && onSuccess();
+                },
             }
         );
     };


### PR DESCRIPTION
## 📝 Description

It relates to the training flow revamp. The issue was that when user started a training dialog did not close automatically.

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [X] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
