### PR TITLE
Use wildcard for libgl patch version

### DIFF
--- a/interactive_ai/services/model_registration/Dockerfile
+++ b/interactive_ai/services/model_registration/Dockerfile
@@ -27,8 +27,8 @@ FROM base AS runtime
 # Install runtime dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libgl1=1.6.0-1 \
-    libglib2.0-0=2.74.6-2+deb12u5 && \
+    libgl1=1.6.* \
+    libglib2.0-0=2.74.* && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -l -u 10001 non-root && \
 	pip3 uninstall -y setuptools pip wheel && \

--- a/interactive_ai/workflows/geti_domain/dataset_ie/Dockerfile
+++ b/interactive_ai/workflows/geti_domain/dataset_ie/Dockerfile
@@ -38,8 +38,8 @@ FROM base AS runtime
 # Install runtime dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg=7:5.1.6-0+deb12u1 \
-    libgl1=1.6.0-1 \
-    libglib2.0-0=2.74.6-2+deb12u5 \
+    libgl1=1.6.* \
+    libglib2.0-0=2.74.* \
     curl && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -l -u 10001 non-root && \

--- a/interactive_ai/workflows/geti_domain/model_test/Dockerfile
+++ b/interactive_ai/workflows/geti_domain/model_test/Dockerfile
@@ -30,8 +30,8 @@ FROM base AS runtime
 # Install runtime dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libgl1=1.6.0-1 \
-    libglib2.0-0=2.74.6-2+deb12u5 \
+    libgl1=1.6.* \
+    libglib2.0-0=2.74.* \
     curl && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -l -u 10001 non-root && \

--- a/interactive_ai/workflows/geti_domain/optimize/Dockerfile
+++ b/interactive_ai/workflows/geti_domain/optimize/Dockerfile
@@ -38,8 +38,8 @@ FROM base AS runtime
 # Install runtime dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libgl1=1.6.0-1 \
-    libglib2.0-0=2.74.6-2+deb12u5 \
+    libgl1=1.6.* \
+    libglib2.0-0=2.74.* \
     curl && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -l -u 10001 non-root && \

--- a/interactive_ai/workflows/geti_domain/project_ie/Dockerfile
+++ b/interactive_ai/workflows/geti_domain/project_ie/Dockerfile
@@ -31,8 +31,8 @@ FROM base AS runtime
 # Install runtime dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libgl1=1.6.0-1 \
-    libglib2.0-0=2.74.6-2+deb12u5 \
+    libgl1=1.6.* \
+    libglib2.0-0=2.74.* \
     curl && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -l -u 10001 non-root && \

--- a/interactive_ai/workflows/geti_domain/train/Dockerfile
+++ b/interactive_ai/workflows/geti_domain/train/Dockerfile
@@ -38,8 +38,8 @@ FROM base AS runtime
 # Install runtime dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libgl1=1.6.0-1 \
-    libglib2.0-0=2.74.6-2+deb12u5 \
+    libgl1=1.6.* \
+    libglib2.0-0=2.74.* \
     curl && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -l -u 10001 non-root && \

--- a/interactive_ai/workflows/otx_domain/trainer/otx_v2/Dockerfile
+++ b/interactive_ai/workflows/otx_domain/trainer/otx_v2/Dockerfile
@@ -62,8 +62,8 @@ FROM base AS runtime
 # Install runtime dependencies
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libgl1=1.6.0-1 \
-    libglib2.0-0=2.74.6-2+deb12u5 \
+    libgl1=1.6.* \
+    libglib2.0-0=2.74.* \
     curl && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -l -u 10001 non-root && \


### PR DESCRIPTION
Fix broken libgl install by using a wildcard for the patch version instead of exact version. 

https://jira.devtools.intel.com/browse/ITEP-67173
