### PR TITLE
ITEP-67586 workaround: use YOLO-X as default model for detection autotraining [2.10]

### DIFF
--- a/interactive_ai/services/director/app/usecases/auto_train/kafka_handler.py
+++ b/interactive_ai/services/director/app/usecases/auto_train/kafka_handler.py
@@ -2,13 +2,21 @@
 # LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 
 
+import logging
+
 from coordination.dataset_manager.dynamic_required_num_annotations import DynamicRequiredAnnotations
+from environment import get_gpu_provider
 
 from .auto_train_use_case import AutoTrainUseCase
 from geti_kafka_tools import BaseKafkaHandler, KafkaRawMessage, TopicSubscription
 from geti_telemetry_tools import unified_tracing
 from geti_types import ID, ProjectIdentifier, Singleton
+from iai_core.algorithms import ModelTemplateList
+from iai_core.repos import ProjectRepo
+from iai_core.services import ModelService
 from iai_core.session.session_propagation import setup_session_kafka
+
+logger = logging.getLogger(__name__)
 
 
 class AutoTrainingKafkaHandler(BaseKafkaHandler, metaclass=Singleton):
@@ -21,7 +29,7 @@ class AutoTrainingKafkaHandler(BaseKafkaHandler, metaclass=Singleton):
 
     @property
     def topics_subscriptions(self) -> list[TopicSubscription]:
-        return [
+        subs = [
             TopicSubscription(topic="configuration_changes", callback=self.on_configuration_changed),
             TopicSubscription(
                 topic="dataset_counters_updated",
@@ -30,10 +38,48 @@ class AutoTrainingKafkaHandler(BaseKafkaHandler, metaclass=Singleton):
             TopicSubscription(topic="training_successful", callback=self.on_training_successful),
             TopicSubscription(topic="model_activated", callback=self.on_model_activated),
         ]
+        # Workaround (ITEP-67586): change some model defaults for Intel GPU
+        # This is done by reconfiguring the active model immediately after project creation
+        if get_gpu_provider() == "intel":
+            subs.append(TopicSubscription(topic="project_creations", callback=self.on_project_created))
+        return subs
 
     def stop(self) -> None:
         super().stop()
         self.auto_train_use_case.stop()
+
+    @setup_session_kafka
+    @unified_tracing
+    def on_project_created(self, raw_message: KafkaRawMessage) -> None:
+        # Workaround (ITEP-67586): change some model defaults for Intel GPU
+        # This is done by reconfiguring the active model immediately after project creation
+        value: dict = raw_message.value
+        project_identifier = ProjectIdentifier(
+            workspace_id=ID(value["workspace_id"]), project_id=ID(value["project_id"])
+        )
+        project = ProjectRepo().get_by_id(project_identifier.project_id)
+        for task_node in project.get_trainable_task_nodes():
+            task_type = task_node.task_properties.task_type
+            try:
+                default_model_template_id = next(
+                    model_template.model_template_id
+                    for model_template in ModelTemplateList().get_all()
+                    if model_template.task_type == task_type and model_template.is_default_for_task
+                )
+            except StopIteration:
+                logger.error("Could not resolve default model template for task type %s", task_type)
+                return
+            logger.info(
+                "[WORKAROUND] Switching active model storage to '%s' for task '%s'",
+                default_model_template_id,
+                task_node,
+            )
+            model_storage = ModelService.get_or_create_model_storage(
+                project_identifier=project_identifier,
+                task_node=task_node,
+                model_template_id=default_model_template_id,
+            )
+            ModelService.activate_model_storage(model_storage)
 
     @setup_session_kafka
     @unified_tracing


### PR DESCRIPTION
## 📝 Description

Extending the workaround of #260 to also take effect on auto-training. The trick is to switch the active model right after project creation, to align it with the default one configured in the director ms templates.

JIRA: [ITEP-67586](https://jira.devtools.intel.com/browse/ITEP-67586)

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
