### PR TITLE
gh-295 Fix not begin able to load test results

### DIFF
--- a/web_ui/src/core/media/media-filter.interface.ts
+++ b/web_ui/src/core/media/media-filter.interface.ts
@@ -10,7 +10,7 @@ export enum SortMenuActionKey {
 
 export interface AdvancedFilterSortingOptions {
     sortBy?: string;
-    sortDir?: string;
+    sortDir?: 'asc' | 'dsc';
 }
 
 // Note: condition = undefined is only when we add an empty filter rule

--- a/web_ui/src/core/services/urls.ts
+++ b/web_ui/src/core/services/urls.ts
@@ -620,7 +620,7 @@ const TEST_MEDIA_FILTER = (
 
     if (sortingOptions?.sortBy) {
         searchOptionsUrl.set('sort_by', sortingOptions?.sortBy ?? 'score');
-        searchOptionsUrl.set('sort_direction', sortingOptions?.sortDir ?? 'asc');
+        searchOptionsUrl.set('sort_direction', sortingOptions?.sortDir?.toLocaleLowerCase() ?? 'asc');
     }
 
     searchOptionsUrl.set('limit', mediaItemsLoadSize?.toString() ?? '');

--- a/web_ui/src/core/services/urls.ts
+++ b/web_ui/src/core/services/urls.ts
@@ -620,7 +620,7 @@ const TEST_MEDIA_FILTER = (
 
     if (sortingOptions?.sortBy) {
         searchOptionsUrl.set('sort_by', sortingOptions?.sortBy ?? 'score');
-        searchOptionsUrl.set('sort_direction', sortingOptions?.sortDir?.toLocaleLowerCase() ?? 'asc');
+        searchOptionsUrl.set('sort_direction', sortingOptions?.sortDir ?? 'asc');
     }
 
     searchOptionsUrl.set('limit', mediaItemsLoadSize?.toString() ?? '');

--- a/web_ui/src/hooks/use-sorting-params/use-sorting-params.hook.ts
+++ b/web_ui/src/hooks/use-sorting-params/use-sorting-params.hook.ts
@@ -16,7 +16,7 @@ export const useSortingParams = () => {
 
     const sortingOptions: AdvancedFilterSortingOptions = {
         sortBy: searchParams.get('sortBy') ?? SortMenuActionKey.DATE,
-        sortDir: searchParams.get('sortDirection') ?? 'dsc',
+        sortDir: searchParams.get('sortDirection') === 'asc' ? 'asc' : 'dsc',
     };
 
     return {

--- a/web_ui/src/pages/media/media-actions/media-sorting.component.tsx
+++ b/web_ui/src/pages/media/media-actions/media-sorting.component.tsx
@@ -33,7 +33,7 @@ export const MediaSorting = ({
 
     const onSortMenuAction = (key: Key) => {
         const [sortBy, sortDir] = String(key).split(KEY_SEPARATOR);
-        setSortingOptions({ sortBy: sortBy.toUpperCase(), sortDir });
+        setSortingOptions({ sortBy: sortBy.toUpperCase(), sortDir: sortDir === 'asc' ? 'asc' : 'dsc' });
     };
 
     return (

--- a/web_ui/src/pages/project-details/components/project-test/media-items-bucket.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-test/media-items-bucket.component.tsx
@@ -52,7 +52,7 @@ export const MediaItemsBucket = ({
     const { useMediaItemsOfTestQuery } = useTests();
     const testMediaItemsQuery = useMediaItemsOfTestQuery(projectIdentifier, testId ?? '', mediaFilterOptions, {
         sortBy: SearchRuleField.Score,
-        sortDir: sortDirection,
+        sortDir: sortDirection === SortDirection.ASC ? 'asc' : 'dsc',
     });
     const { isFetchingNextPage, hasNextPage, fetchNextPage, data: mediaData } = testMediaItemsQuery;
 

--- a/web_ui/src/pages/project-details/components/project-test/test-details-preview/test-details-preview.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-test/test-details-preview/test-details-preview.component.tsx
@@ -102,7 +102,7 @@ const TestDetailsPreviewContent = ({
 
     const testMediaItemsQuery = useMediaItemsOfTestQuery(projectIdentifier, testId ?? '', filter, {
         sortBy: SearchRuleField.Score,
-        sortDir,
+        sortDir: sortDir === SortDirection.ASC ? 'asc' : 'dsc',
     });
 
     const { isFetching, hasNextPage, fetchNextPage } = testMediaItemsQuery;

--- a/web_ui/src/providers/media-upload-provider/use-media-upload-mutations.ts
+++ b/web_ui/src/providers/media-upload-provider/use-media-upload-mutations.ts
@@ -28,7 +28,7 @@ interface UseMediaUploadQueries {
 }
 
 const getMediaQueryFilter = (datasetIdentifier: DatasetIdentifier, labelIds: string[]) => {
-    const queryKey = QUERY_KEYS.ADVANCED_MEDIA_ITEMS(datasetIdentifier, {}, { sortBy: '', sortDir: '' });
+    const queryKey = QUERY_KEYS.ADVANCED_MEDIA_ITEMS(datasetIdentifier, {}, { sortBy: '', sortDir: undefined });
 
     return {
         // First find all queries related to fetching media, ignoring the filters and sorting options

--- a/web_ui/tests/e2e/daily/card-suit-classification.spec.ts
+++ b/web_ui/tests/e2e/daily/card-suit-classification.spec.ts
@@ -150,6 +150,9 @@ test(
 
             // The model should be better than just throwing a coin
             expect(score).toBeGreaterThanOrEqual(25);
+            await expect(async () => {
+                expect(await testPage.countImages()).toBe(32);
+            }).toPass();
             console.info('Simple Card classification finished!');
         });
     }

--- a/web_ui/tests/fixtures/page-objects/test-page.ts
+++ b/web_ui/tests/fixtures/page-objects/test-page.ts
@@ -30,7 +30,7 @@ export class ProjectTestPage {
     async countImages() {
         const info = this.page.getByText(/(\d)+ images, (\d)+ frames from (\d)+ videos/i);
         const imagesInBucketBelowThreshold = this.getImagesCount(await info.nth(0).textContent());
-        const imagesInBucketAboveThreshold = this.getImagesCount(await info.nth(0).textContent());
+        const imagesInBucketAboveThreshold = this.getImagesCount(await info.nth(1).textContent());
 
         return imagesInBucketBelowThreshold + imagesInBucketAboveThreshold;
     }


### PR DESCRIPTION
## 📝 Description

I think this was a regression from #258, most likely by combining a duplicated [SortDirection](https://github.com/open-edge-platform/geti/pull/258/commits/1e1c3c41b44a240bffa5160b16efccb42cae31e8#diff-c94851f3462c06404434404947f588fa5f86349e390d55f472ec246547ba96b2L15) we accidentally changed the value used when sorting test results to be `ASC` and `DESC` instead of the lower case variants.

While we had e2e tests that check the test results these tests only checked the test score and would finish before triggering the error reported in #295.

Fixes #295 

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [x] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [x] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
