### PR TITLE
ITEP-31796 Remove interval job handlers from dataset import

### DIFF
--- a/web_ui/src/core/datasets/hooks/use-dataset-import-queries.hook.ts
+++ b/web_ui/src/core/datasets/hooks/use-dataset-import-queries.hook.ts
@@ -156,19 +156,13 @@ export const useDatasetImportQueries = (): UseDatasetImportQueries => {
         }, [intervalHandlers]);
 
         useEffect(() => {
-            if (!enabled || !query.isSuccess) {
-                return;
+            if (!enabled) return;
+            if (query.isSuccess) {
+                getIntervalJobHandlers(intervalHandlersRef.current)(query.data);
+            } else if (query.isError && query.error !== null) {
+                intervalHandlersRef.current.onError(query.error);
             }
-            getIntervalJobHandlers(intervalHandlersRef.current)(query.data);
-        }, [enabled, query.isSuccess, query.data]);
-
-        useEffect(() => {
-            if (!query.isError || query.error === null) {
-                return;
-            }
-
-            intervalHandlersRef.current.onError(query.error);
-        }, [query.isError, query.error]);
+        }, [enabled, query.isSuccess, query.data, query.isError, query.error]);
 
         return query;
     };
@@ -192,19 +186,13 @@ export const useDatasetImportQueries = (): UseDatasetImportQueries => {
         }, [intervalHandlers]);
 
         useEffect(() => {
-            if (!enabled || !query.isSuccess) {
-                return;
+            if (!enabled) return;
+            if (query.isSuccess) {
+                getIntervalJobHandlers(intervalHandlersRef.current)(query.data);
+            } else if (query.isError && query.error !== null) {
+                intervalHandlersRef.current.onError(query.error);
             }
-            getIntervalJobHandlers(intervalHandlersRef.current)(query.data);
-        }, [enabled, query.isSuccess, query.data]);
-
-        useEffect(() => {
-            if (!query.isError || query.error === null) {
-                return;
-            }
-
-            intervalHandlersRef.current.onError(query.error);
-        }, [query.isError, query.error]);
+        }, [enabled, query.data, query.isSuccess, query.isError, query.error]);
 
         return query;
     };
@@ -228,19 +216,13 @@ export const useDatasetImportQueries = (): UseDatasetImportQueries => {
         }, [intervalHandlers]);
 
         useEffect(() => {
-            if (!enabled || !query.isSuccess) {
-                return;
+            if (!enabled) return;
+            if (query.isSuccess) {
+                getIntervalJobHandlers(intervalHandlersRef.current)(query.data);
+            } else if (query.isError && query.error !== null) {
+                intervalHandlersRef.current.onError(query.error);
             }
-            getIntervalJobHandlers(intervalHandlersRef.current)(query.data);
-        }, [enabled, query.isSuccess, query.data]);
-
-        useEffect(() => {
-            if (!query.isError || query.error === null) {
-                return;
-            }
-
-            intervalHandlersRef.current.onError(query.error);
-        }, [query.isError, query.error]);
+        }, [enabled, query.isSuccess, query.data, query.isError, query.error]);
 
         return query;
     };
@@ -250,6 +232,7 @@ export const useDatasetImportQueries = (): UseDatasetImportQueries => {
         enabled = true,
         ...intervalHandlers
     }) => {
+        console.log('useImportingExistingProjectStatusJob');
         const intervalHandlersRef = useRef(intervalHandlers);
 
         const query = useQuery<JobImportDatasetToExistingProjectStatus, AxiosError>({
@@ -264,20 +247,13 @@ export const useDatasetImportQueries = (): UseDatasetImportQueries => {
         }, [intervalHandlers]);
 
         useEffect(() => {
-            if (!enabled || !query.isSuccess) {
-                return;
+            if (!enabled) return;
+            if (query.isSuccess) {
+                getIntervalJobHandlers(intervalHandlersRef.current)(query.data);
+            } else if (query.isError && query.error !== null) {
+                intervalHandlersRef.current.onError(query.error);
             }
-
-            getIntervalJobHandlers(intervalHandlersRef.current)(query.data);
-        }, [enabled, query.isSuccess, query.data]);
-
-        useEffect(() => {
-            if (!query.isError || query.error === null) {
-                return;
-            }
-
-            intervalHandlersRef.current.onError(query.error);
-        }, [query.isError, query.error]);
+        }, [enabled, query.isSuccess, query.data, query.isError, query.error]);
 
         return query;
     };

--- a/web_ui/src/core/datasets/hooks/use-dataset-import-queries.hook.ts
+++ b/web_ui/src/core/datasets/hooks/use-dataset-import-queries.hook.ts
@@ -232,7 +232,6 @@ export const useDatasetImportQueries = (): UseDatasetImportQueries => {
         enabled = true,
         ...intervalHandlers
     }) => {
-        console.log('useImportingExistingProjectStatusJob');
         const intervalHandlersRef = useRef(intervalHandlers);
 
         const query = useQuery<JobImportDatasetToExistingProjectStatus, AxiosError>({

--- a/web_ui/src/pages/project-details/components/project-models/models-container/model-card/model-info-fields.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/models-container/model-card/model-info-fields.component.tsx
@@ -28,9 +28,9 @@ const ModelInfoReady = ({
     totalDiskSize,
     complexity,
 }: {
-    modelSize?: string;
-    totalDiskSize?: string;
-    complexity?: number;
+    modelSize: string | undefined;
+    totalDiskSize: string | undefined;
+    complexity: number | undefined;
 }) => (
     <>
         {modelSize !== undefined && (
@@ -58,6 +58,9 @@ const ModelInfoReady = ({
 );
 
 export const ModelInfoFields = ({
+    modelSize,
+    totalDiskSize,
+    complexity,
     isModelTraining,
 }: {
     modelSize?: string;
@@ -65,5 +68,13 @@ export const ModelInfoFields = ({
     complexity?: number;
     isModelTraining: boolean;
 }) => {
-    return <>{isModelTraining ? <ModelInfoTraining /> : <ModelInfoReady />}</>;
+    return (
+        <>
+            {isModelTraining ? (
+                <ModelInfoTraining />
+            ) : (
+                <ModelInfoReady modelSize={modelSize} totalDiskSize={totalDiskSize} complexity={complexity} />
+            )}
+        </>
+    );
 };

--- a/web_ui/src/pages/project-details/components/project-models/models-container/model-card/model-info-fields.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/models-container/model-card/model-info-fields.component.tsx
@@ -7,10 +7,57 @@ import { ThreeDotsFlashing } from '../../../../../../shared/components/three-dot
 
 import classes from './model-card.module.scss';
 
-export const ModelInfoFields = ({
+const ModelInfoTraining = () => (
+    <>
+        <Text UNSAFE_className={classes.modelInfo} data-testid={'model-size-id'}>
+            Model weight size: <ThreeDotsFlashing className={classes.threeDotsFlashing} />
+        </Text>
+        <Text marginX={'size-50'}>|</Text>
+        <Text UNSAFE_className={classes.modelInfo} data-testid={'total-disk-size-id'}>
+            Total size: <ThreeDotsFlashing className={classes.threeDotsFlashing} />
+        </Text>
+        <Text marginX={'size-50'}>|</Text>
+        <Text UNSAFE_className={classes.modelInfo} data-testid={'complexity-id'}>
+            Complexity: <ThreeDotsFlashing className={classes.threeDotsFlashing} />
+        </Text>
+    </>
+);
+
+const ModelInfoReady = ({
     modelSize,
     totalDiskSize,
     complexity,
+}: {
+    modelSize?: string;
+    totalDiskSize?: string;
+    complexity?: number;
+}) => (
+    <>
+        {modelSize !== undefined && (
+            <>
+                <Text UNSAFE_className={classes.modelInfo} data-testid={'model-size-id'}>
+                    Model weight size: {modelSize}
+                </Text>
+                <Text marginX={'size-50'}>|</Text>
+            </>
+        )}
+        {totalDiskSize !== undefined && (
+            <>
+                <Text UNSAFE_className={classes.modelInfo} data-testid={'total-disk-size-id'}>
+                    Total size: {totalDiskSize}
+                </Text>
+                <Text marginX={'size-50'}>|</Text>
+            </>
+        )}
+        {complexity !== undefined && (
+            <Text UNSAFE_className={classes.modelInfo} data-testid={'complexity-id'}>
+                Complexity: {complexity} GFlops
+            </Text>
+        )}
+    </>
+);
+
+export const ModelInfoFields = ({
     isModelTraining,
 }: {
     modelSize?: string;
@@ -18,47 +65,5 @@ export const ModelInfoFields = ({
     complexity?: number;
     isModelTraining: boolean;
 }) => {
-    return (
-        <>
-            {isModelTraining ? (
-                <>
-                    <Text UNSAFE_className={classes.modelInfo} data-testid={'model-size-id'}>
-                        Model weight size: <ThreeDotsFlashing className={classes.threeDotsFlashing} />
-                    </Text>
-                    <Text marginX={'size-50'}>|</Text>
-                    <Text UNSAFE_className={classes.modelInfo} data-testid={'total-disk-size-id'}>
-                        Total size: <ThreeDotsFlashing className={classes.threeDotsFlashing} />
-                    </Text>
-                    <Text marginX={'size-50'}>|</Text>
-                    <Text UNSAFE_className={classes.modelInfo} data-testid={'complexity-id'}>
-                        Complexity: <ThreeDotsFlashing className={classes.threeDotsFlashing} />
-                    </Text>
-                </>
-            ) : (
-                <>
-                    {modelSize !== undefined && (
-                        <>
-                            <Text UNSAFE_className={classes.modelInfo} data-testid={'model-size-id'}>
-                                Model weight size: {modelSize}
-                            </Text>
-                            <Text marginX={'size-50'}>|</Text>
-                        </>
-                    )}
-                    {totalDiskSize !== undefined && (
-                        <>
-                            <Text UNSAFE_className={classes.modelInfo} data-testid={'total-disk-size-id'}>
-                                Total size: {totalDiskSize}
-                            </Text>
-                            <Text marginX={'size-50'}>|</Text>
-                        </>
-                    )}
-                    {complexity !== undefined && (
-                        <Text UNSAFE_className={classes.modelInfo} data-testid={'complexity-id'}>
-                            Complexity: {complexity} GFlops
-                        </Text>
-                    )}
-                </>
-            )}
-        </>
-    );
+    return <>{isModelTraining ? <ModelInfoTraining /> : <ModelInfoReady />}</>;
 };

--- a/web_ui/src/pages/project-details/components/project-models/models-container/training-model-card/training-model-card.test.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/models-container/training-model-card/training-model-card.test.tsx
@@ -54,6 +54,29 @@ jest.mock('../../../../../../core/supported-algorithms/hooks/use-tasks-with-supp
     }),
 }));
 
+const formattedCreationDate = formatDate(dayjs().toString(), 'DD MMM YYYY, hh:mm A');
+const mockedRunningTrainingJob: RunningTrainingJob = getMockedJob({
+    state: JobState.RUNNING,
+    type: JobType.TRAIN,
+    creationTime: formattedCreationDate,
+    metadata: {
+        task: {
+            taskId: 'segmentation-id',
+            modelArchitecture: 'SSD',
+            name: 'Segmentation',
+            datasetStorageId: 'dataset-storage-id',
+            modelTemplateId: 'template-id',
+        },
+        project: {
+            id: '123',
+            name: 'example project',
+        },
+        trainedModel: {
+            modelId: 'model-id',
+        },
+    },
+}) as RunningTrainingJob;
+
 describe('TrainingModelCard', () => {
     const render = async ({ job, modelGroup }: { job: RunningTrainingJob; modelGroup: ModelsGroups[] }) => {
         const modelsService = createInMemoryModelsService();
@@ -75,30 +98,9 @@ describe('TrainingModelCard', () => {
 
     it('should display increased model version from the previously trained model, creation time, loading model info and inform that score is not available', async () => {
         const formattedCreationDate = formatDate(dayjs().toString(), 'DD MMM YYYY, hh:mm A');
-        const mockedJob = getMockedJob({
-            state: JobState.RUNNING,
-            type: JobType.TRAIN,
-            creationTime: formattedCreationDate,
-            metadata: {
-                task: {
-                    taskId: 'segmentation-id',
-                    modelArchitecture: 'SSD',
-                    name: 'Segmentation',
-                    datasetStorageId: 'dataset-storage-id',
-                    modelTemplateId: 'template-id',
-                },
-                project: {
-                    id: '123',
-                    name: 'example project',
-                },
-                trainedModel: {
-                    modelId: 'model-id',
-                },
-            },
-        }) as RunningTrainingJob;
-        const mockedGenericId = `training-model-${mockedJob.metadata.trainedModel.modelId}`;
+        const mockedGenericId = `training-model-${mockedRunningTrainingJob.metadata.trainedModel.modelId}`;
         const mockedModelGroup = [getMockedModelGroups()];
-        await render({ job: mockedJob, modelGroup: mockedModelGroup });
+        await render({ job: mockedRunningTrainingJob, modelGroup: mockedModelGroup });
 
         expect(screen.getByTestId(`version-${mockedGenericId}-id`)).toHaveTextContent(
             `Version ${mockedModelGroup[0].modelVersions[0].version + 1}`
@@ -117,30 +119,8 @@ describe('TrainingModelCard', () => {
     });
 
     it('should display model version 1 if there were not previously trained model in that architecture, creation time, loading model info and inform that score is not available', async () => {
-        const formattedCreationDate = formatDate(dayjs().toString(), 'DD MMM YYYY, hh:mm A');
-        const mockedJob = getMockedJob({
-            state: JobState.RUNNING,
-            type: JobType.TRAIN,
-            creationTime: formattedCreationDate,
-            metadata: {
-                task: {
-                    taskId: 'segmentation-id',
-                    modelArchitecture: 'SSD',
-                    name: 'Segmentation',
-                    datasetStorageId: 'dataset-storage-id',
-                    modelTemplateId: 'template-id',
-                },
-                project: {
-                    id: '123',
-                    name: 'example project',
-                },
-                trainedModel: {
-                    modelId: 'model-id',
-                },
-            },
-        }) as RunningTrainingJob;
-        const mockedGenericId = `training-model-${mockedJob.metadata.trainedModel.modelId}`;
-        await render({ job: mockedJob, modelGroup: [] });
+        const mockedGenericId = `training-model-${mockedRunningTrainingJob.metadata.trainedModel.modelId}`;
+        await render({ job: mockedRunningTrainingJob, modelGroup: [] });
 
         expect(screen.getByTestId(`version-${mockedGenericId}-id`)).toHaveTextContent(`Version 1`);
 


### PR DESCRIPTION
## 📝 Description

Since onSuccess and onError callbacks are no longer supported as options directly in the useQuery hook we still need to handle success and error states using the returned query result inside the hook, so I didn't find the way to remove that completely. What I did is merged handling  success and error in a single useEffect to simplify and make it more readable.

Other than that I made minor improvements related to my last PR (https://github.com/open-edge-platform/geti/pull/268).

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: ITEP-31796

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
