### PR TITLE
fix: Check value of data instead of current in `useDeploymentConfig`

### DIFF
--- a/web_ui/packages/core/src/services/use-deployment-config-query.hook.test.tsx
+++ b/web_ui/packages/core/src/services/use-deployment-config-query.hook.test.tsx
@@ -58,7 +58,7 @@ describe('useDeploymentConfigQuery', () => {
             const { result } = renderDeploymentConfigHook();
 
             await waitFor(() => {
-                expect(result.current).not.toBeNull();
+                expect(result.current.data).not.toBeUndefined();
             });
 
             const data = result.current.data;
@@ -74,7 +74,7 @@ describe('useDeploymentConfigQuery', () => {
             const { result } = renderDeploymentConfigHook({ isAdmin: true });
 
             await waitFor(() => {
-                expect(result.current).not.toBeNull();
+                expect(result.current.data).not.toBeUndefined();
             });
 
             const data = result.current.data;
@@ -99,7 +99,7 @@ describe('useDeploymentConfigQuery', () => {
         const { result } = renderDeploymentConfigHook();
 
         await waitFor(() => {
-            expect(result.current).not.toBeUndefined();
+            expect(result.current.data).not.toBeUndefined();
         });
 
         const data = result.current.data;
@@ -133,7 +133,7 @@ describe('useDeploymentConfigQuery', () => {
         const { result } = renderDeploymentConfigHook({ isAdmin: true });
 
         await waitFor(() => {
-            expect(result.current).not.toBeUndefined();
+            expect(result.current.data).not.toBeUndefined();
         });
 
         const data = result.current.data;
@@ -168,7 +168,7 @@ describe('useDeploymentConfigQuery', () => {
         const { result } = renderDeploymentConfigHook({ isAdmin: true });
 
         await waitFor(() => {
-            expect(result.current).not.toBeUndefined();
+            expect(result.current.data).not.toBeUndefined();
         });
 
         const data = result.current.data;
@@ -201,7 +201,7 @@ describe('useDeploymentConfigQuery', () => {
         const { result } = renderDeploymentConfigHook({ isAdmin: true });
 
         await waitFor(() => {
-            expect(result.current).not.toBeUndefined();
+            expect(result.current.data).not.toBeUndefined();
         });
 
         const data = result.current.data;
@@ -238,7 +238,7 @@ describe('useDeploymentConfigQuery', () => {
         const { result } = renderDeploymentConfigHook({ isAdmin: true });
 
         await waitFor(() => {
-            expect(result.current).not.toBeUndefined();
+            expect(result.current.data).not.toBeUndefined();
         });
 
         const data = result.current.data;
@@ -261,7 +261,7 @@ describe('useDeploymentConfigQuery', () => {
         const { result } = renderDeploymentConfigHook();
 
         await waitFor(() => {
-            expect(result.current).not.toBeUndefined();
+            expect(result.current.data).not.toBeUndefined();
         });
 
         const data = result.current.data;
@@ -285,7 +285,7 @@ describe('useDeploymentConfigQuery', () => {
             const { result } = renderDeploymentConfigHook();
 
             await waitFor(() => {
-                expect(result.current).not.toBeUndefined();
+                expect(result.current.data).not.toBeUndefined();
             });
 
             const data = result.current.data;
@@ -307,7 +307,7 @@ describe('useDeploymentConfigQuery', () => {
             const { result } = renderDeploymentConfigHook();
 
             await waitFor(() => {
-                expect(result.current).not.toBeUndefined();
+                expect(result.current.data).not.toBeUndefined();
             });
 
             const data = result.current.data;


### PR DESCRIPTION
## 📝 Description

The goal of this PR is to fix flaky https://github.com/open-edge-platform/geti/actions/runs/15324057289/job/43114097501.
Tho I don't know why it took 29s there. The next time (if it does not help) I'd give a try replacing mocking api network request by mocking api service.

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [X] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
