### PR TITLE
ITEP-36150 Redundant call to setErrorResponse removed

### DIFF
--- a/platform/services/auth_proxy/app/request_processor/common.go
+++ b/platform/services/auth_proxy/app/request_processor/common.go
@@ -68,7 +68,7 @@ func (h *RequestHandler) getUserDataFromCacheOrService(subject, jwtExternalStrin
 	h.Logger.Debugf("Cache MISS for UserData related to JWT %q", jwtExternalString)
 	currentUser, err := h.dispatchGetUserRequest(subject)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to get user information (external ID %s) from the account service: %v", subject, err)
+		return nil, false, fmt.Errorf("failed to get user information (external ID %s): %v", subject, err)
 	}
 	return currentUser, false, nil
 }

--- a/platform/services/auth_proxy/app/request_processor/common.go
+++ b/platform/services/auth_proxy/app/request_processor/common.go
@@ -68,7 +68,6 @@ func (h *RequestHandler) getUserDataFromCacheOrService(subject, jwtExternalStrin
 	h.Logger.Debugf("Cache MISS for UserData related to JWT %q", jwtExternalString)
 	currentUser, err := h.dispatchGetUserRequest(subject)
 	if err != nil {
-		h.setErrorResponse(v32.StatusCode_InternalServerError, "Internal server error")
 		return nil, false, fmt.Errorf("failed to get user information (external ID %s) from the account service: %v", subject, err)
 	}
 	return currentUser, false, nil


### PR DESCRIPTION
## 📝 Description

This PR fixes `Unauthorized` response code being overwritten by `Internal Server Error`.
All other calls to `setErrorResponse` are unique and not overwritten.

JIRA: ITEP-36150

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
