### PR TITLE
fix: Use training dialog wrapper with credits for anomaly

### DIFF
--- a/web_ui/src/pages/project-details/components/project-media/training-notification/anomaly-projects-notification.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-media/training-notification/anomaly-projects-notification.component.tsx
@@ -9,7 +9,7 @@ import { useProjectIdentifier } from '../../../../../hooks/use-project-identifie
 import { NOTIFICATION_TYPE } from '../../../../../notification/notification-toast/notification-type.enum';
 import { useNotification } from '../../../../../notification/notification.component';
 import { QuietToggleButton } from '../../../../../shared/components/quiet-button/quiet-toggle-button.component';
-import { TrainModel } from '../../project-models/train-model-dialog/train-model-dialog.component';
+import { CreditBalanceTrainDialog } from '../../project-models/train-model-dialog/credit-balance-train-dialog.component';
 import { useShowStartTraining } from './use-show-start-training.hook';
 
 export const AnomalyProjectsNotification = () => {
@@ -21,7 +21,7 @@ export const AnomalyProjectsNotification = () => {
     useShowStartTraining(trainModelDialogState);
 
     return (
-        <TrainModel
+        <CreditBalanceTrainDialog
             isOpen={trainModelDialogState.isOpen}
             onClose={() => {
                 removeNotifications();
@@ -32,7 +32,7 @@ export const AnomalyProjectsNotification = () => {
                 addNotification({
                     message: 'Training has started',
                     type: NOTIFICATION_TYPE.DEFAULT,
-                    dismiss: { duration: 0 }, // We dont want the notification to be dismissed automatically
+                    dismiss: { duration: 0 }, // We don't want the notification to be dismissed automatically
                     actionButtons: [
                         <QuietToggleButton
                             key={'open-train-model'}


### PR DESCRIPTION
## 📝 Description

The issue was that in case of anomaly project we were not showing the training dialog with credits (therefore we were not showing proper training dialog (new/legacy) based on the feature flag)

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [X] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
