### PR TITLE
ITEP-36981: Omit job updates for already cancelled jobs

### DIFF
--- a/interactive_ai/services/jobs/app/scheduler/kafka_handler.py
+++ b/interactive_ai/services/jobs/app/scheduler/kafka_handler.py
@@ -306,6 +306,9 @@ class ProgressHandler(BaseKafkaHandler, metaclass=Singleton):
             return
 
         job_id = Flyte.get_execution_job_id(execution)
+        job = StateMachine().get_by_id(job_id=ID(job_id))
+        if job.cancellation_info.is_cancelled:
+            return
 
         progress: float | None = value.get("progress")
         message: str | None = value.get("message")


### PR DESCRIPTION
## 📝 Description

Currently if a job is cancelled, it still can report failure messages. For example if it performs network requests with retries and istio sidecar is already terminated. In this case not to display confusing message in the UI, scheduler will just omit them

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [x] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
