### PR TITLE
Redirect user based on local storage instead of user settings

### DIFF
--- a/web_ui/src/core/organizations/hook/use-selected-organization.hook.test.tsx
+++ b/web_ui/src/core/organizations/hook/use-selected-organization.hook.test.tsx
@@ -9,13 +9,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import * as usehooks from 'usehooks-ts';
 
 import { paths } from '../../../../packages/core/src/services/routes';
-import {
-    getMockedUserGlobalSettings,
-    getMockedUserGlobalSettingsObject,
-} from '../../../test-utils/mocked-items-factory/mocked-settings';
 import { renderHookWithProviders } from '../../../test-utils/render-hook-with-providers';
-import { GENERAL_SETTINGS_KEYS } from '../../user-settings/dtos/user-settings.interface';
-import { useUserGlobalSettings } from '../../user-settings/hooks/use-global-settings.hook';
 import { AccountStatus } from '../organizations.interface';
 import { useSelectedOrganization } from './use-selected-organization.hook';
 
@@ -196,13 +190,6 @@ describe('useSelectedOrganization', () => {
             ['requested access', mockedRequestedOrganization],
         ])('avoids redirection when the chosen organization has a status: %s', async (_, organization) => {
             const mockedNavigate = mockNavigate();
-            jest.mocked(useUserGlobalSettings).mockReturnValue(
-                getMockedUserGlobalSettingsObject({
-                    config: getMockedUserGlobalSettings({
-                        [GENERAL_SETTINGS_KEYS.CHOSEN_ORGANIZATION]: { value: organization.id },
-                    }),
-                })
-            );
             updateOrganizationQuery([mockedOrganization, organization]);
             renderSelectedOrganizationHook(onboardingService);
 

--- a/web_ui/src/core/organizations/hook/use-selected-organization.hook.ts
+++ b/web_ui/src/core/organizations/hook/use-selected-organization.hook.ts
@@ -17,9 +17,6 @@ import { useNotification } from '../../../notification/notification.component';
 import { isActiveOrganization, isUserActivatedInOrg, isUserInvitedInOrg } from '../../../routes/organizations/util';
 import { LOCAL_STORAGE_KEYS } from '../../../shared/local-storage-keys';
 import { hasEqualId } from '../../../shared/utils';
-import { GENERAL_SETTINGS_KEYS } from '../../user-settings/dtos/user-settings.interface';
-import { useUserGlobalSettings } from '../../user-settings/hooks/use-global-settings.hook';
-import { getSettingsOfType } from '../../user-settings/utils';
 
 const removeLastForwardSlash = (text: string) => text.replace(/\/$/, '');
 

--- a/web_ui/src/core/user-settings/dtos/user-settings.interface.ts
+++ b/web_ui/src/core/user-settings/dtos/user-settings.interface.ts
@@ -69,7 +69,6 @@ export enum GLOBAL_MODALS_KEYS {
 
 export enum GENERAL_SETTINGS_KEYS {
     MAINTENANCE_BANNER = 'maintenanceBanner',
-    CHOSEN_ORGANIZATION = 'chosenOrganization',
 }
 
 export type TutorialKeys = TUTORIAL_CARD_KEYS | FUX_NOTIFICATION_KEYS | FUX_SETTINGS_KEYS;
@@ -88,7 +87,6 @@ interface CanvasSettingsValues<T extends boolean | number> {
 
 export type GeneralSettingsConfig = {
     [GENERAL_SETTINGS_KEYS.MAINTENANCE_BANNER]: { wasDismissed: boolean; window: { start: number; end: number } };
-    [GENERAL_SETTINGS_KEYS.CHOSEN_ORGANIZATION]: { value: null | string };
 };
 
 export type GlobalModalsConfig = Record<GLOBAL_MODALS_KEYS, { isEnabled: boolean }>;

--- a/web_ui/src/core/user-settings/utils.ts
+++ b/web_ui/src/core/user-settings/utils.ts
@@ -99,7 +99,6 @@ const initialGlobalModalsConfig: GlobalModalsConfig = {
 };
 
 export const initialGeneralSettingsConfig: GeneralSettingsConfig = {
-    [GENERAL_SETTINGS_KEYS.CHOSEN_ORGANIZATION]: { value: null },
     [GENERAL_SETTINGS_KEYS.MAINTENANCE_BANNER]: {
         wasDismissed: false,
         window: {

--- a/web_ui/src/pages/landing-page/landing-page-sidebar/landing-page.sidebar.test.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-sidebar/landing-page.sidebar.test.tsx
@@ -2,7 +2,7 @@
 // LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 
 import { paths } from '@geti/core';
-import { screen, waitForElementToBeRemoved, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 
 import { providersRender } from '../../../test-utils/required-providers-render';
 import { LandingPageSidebar } from './landing-page-sidebar.component';
@@ -17,7 +17,6 @@ jest.mock('react-router-dom', () => ({
 describe('Landing page - sidebar', () => {
     it('Check if there are 3 options in sidebar menu - Projects, Account, About', async () => {
         providersRender(<LandingPageSidebar />);
-        await waitForElementToBeRemoved(screen.getByRole('progressbar'));
         const options = within(screen.getByRole('navigation')).getAllByRole('link');
 
         expect(options).toHaveLength(3);
@@ -32,7 +31,6 @@ describe('Landing page - sidebar', () => {
 
     it('Should should show terms of use and privacy', async () => {
         providersRender(<LandingPageSidebar />);
-        await waitForElementToBeRemoved(screen.getByRole('progressbar'));
 
         expect(screen.getByText(/Terms of use/)).toBeInTheDocument();
         expect(screen.getByText(/Privacy/)).toBeInTheDocument();

--- a/web_ui/src/shared/local-storage-keys.ts
+++ b/web_ui/src/shared/local-storage-keys.ts
@@ -16,6 +16,7 @@ export enum LOCAL_STORAGE_KEYS {
     COPY_ANNOTATION = 'copy-annotation',
     LAST_LOGIN_INFO = 'lastLoginInfo',
     MEDIA_VIEW_MODE = 'media-view-mode',
+    LAST_SELECTED_ORGANIZATION_ID = 'last-selected-organization-id',
 }
 
 export const getPanelSettingsKey = (projectId: string) => {


### PR DESCRIPTION
## 📝 Description

Previously we used the user's global settings to determine which organization we wanted to redirect to. This has the disadvantage that we need to wait for loading these settings until we can show the "critical path" of the UI (e.g. the annotator, or project page).
As an alternative this PR uses localstorage to instead store the selected organization. This makes loading the page faster as we don't need to wait for this query to load.

In a follow up PR I'd like to move this redirect logic from the `useEffect` inside of `useSelectedOrganization` into a redirect route inside of our `app-routes` file. This redirect should then only be rendered when the user navigates to say https://geti.dev instead of https://geti.dev/organizations/859a4dc7-a055-47a1-8312-edc7c6b1968c.
Making this follow up change should fix a bug where a user may have more than 1 organization, tries to open a specific url but is redirected because the last time they used geti was on their other organization.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [x] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
