### PR TITLE
ITEP-68215 - Fix training configuration query with model_id

### DIFF
--- a/interactive_ai/libs/iai_core_py/iai_core/entities/model_storage.py
+++ b/interactive_ai/libs/iai_core_py/iai_core/entities/model_storage.py
@@ -8,7 +8,7 @@ import datetime
 from iai_core.entities.model_template import ModelTemplate, NullModelTemplate
 from iai_core.utils.time_utils import now
 
-from geti_types import CTX_SESSION_VAR, ID, PersistentEntity, ProjectIdentifier, ModelStorageIdentifier
+from geti_types import CTX_SESSION_VAR, ID, ModelStorageIdentifier, PersistentEntity, ProjectIdentifier
 
 
 class ModelStorage(PersistentEntity):

--- a/interactive_ai/libs/iai_core_py/iai_core/entities/model_storage.py
+++ b/interactive_ai/libs/iai_core_py/iai_core/entities/model_storage.py
@@ -4,12 +4,11 @@
 """This module implements the Model Storage entity"""
 
 import datetime
-from dataclasses import dataclass
 
 from iai_core.entities.model_template import ModelTemplate, NullModelTemplate
 from iai_core.utils.time_utils import now
 
-from geti_types import CTX_SESSION_VAR, ID, PersistentEntity, ProjectIdentifier
+from geti_types import CTX_SESSION_VAR, ID, PersistentEntity, ProjectIdentifier, ModelStorageIdentifier
 
 
 class ModelStorage(PersistentEntity):
@@ -101,16 +100,3 @@ class NullModelStorage(ModelStorage):
 
     def __repr__(self) -> str:
         return "NullModelStorage()"
-
-
-@dataclass(frozen=True, eq=True)
-class ModelStorageIdentifier:
-    """IDs necessary to uniquely identify a ModelStorage"""
-
-    workspace_id: ID
-    project_id: ID
-    model_storage_id: ID
-
-    @property
-    def project_identifier(self) -> ProjectIdentifier:
-        return ProjectIdentifier(workspace_id=self.workspace_id, project_id=self.project_id)

--- a/interactive_ai/services/director/app/communication/controllers/training_configuration_controller.py
+++ b/interactive_ai/services/director/app/communication/controllers/training_configuration_controller.py
@@ -46,8 +46,22 @@ class TrainingConfigurationRESTController:
             raise TaskNodeNotFoundException(task_node_id=task_id)
 
         if model_id is not None:
-            # TODO ITEP-68215: if model_id is provided, load configuration from the model entity
-            pass
+            model_hyperparams_dict, model_storage = ConfigurationService.get_configuration_from_model(
+                project_identifier=project_identifier,
+                task_id=task_id,
+                model_id=model_id,
+            )
+            if model_hyperparams_dict is None:
+                # TODO ITEP-32067: add backward compatibility to display the old models configurable parameters
+                return {}
+            model_config = PartialTrainingConfiguration.model_validate(
+                {
+                    "task_id": task_id,
+                    "model_manifest_id": model_storage.model_template.model_template_id,
+                    "hyperparameters": model_hyperparams_dict,
+                }
+            )
+            return TrainingConfigurationRESTViews.training_configuration_to_rest(training_configuration=model_config)
 
         if model_manifest_id is None:
             training_configuration_repo = PartialTrainingConfigurationRepo(project_identifier)

--- a/interactive_ai/services/director/app/service/configuration_service.py
+++ b/interactive_ai/services/director/app/service/configuration_service.py
@@ -14,7 +14,7 @@ from storage.repos.partial_training_configuration_repo import PartialTrainingCon
 
 from geti_fastapi_tools.exceptions import ModelNotFoundException
 from geti_types import ID, ModelStorageIdentifier, ProjectIdentifier
-from iai_core.entities.model import Model, NullModel
+from iai_core.entities.model import NullModel
 from iai_core.entities.model_storage import ModelStorage
 from iai_core.repos import ModelRepo, ModelStorageRepo
 
@@ -117,8 +117,6 @@ class ConfigurationService:
         """
         task_model_storages = ModelStorageRepo(project_identifier).get_by_task_node_id(task_id)
 
-        model: Model | None = None
-        found_model_storage: ModelStorage | None = None
         for model_storage in task_model_storages:
             model_storage_identifier = ModelStorageIdentifier(
                 workspace_id=project_identifier.workspace_id,
@@ -127,8 +125,5 @@ class ConfigurationService:
             )
             model = ModelRepo(model_storage_identifier).get_by_id(model_id)
             if not isinstance(model, NullModel):
-                found_model_storage = model_storage
-                break
-        if model is None or found_model_storage is None:
-            raise ModelNotFoundException(model_id)
-        return model.configuration.display_only_configuration, found_model_storage
+                return model.configuration.display_only_configuration, model_storage
+        raise ModelNotFoundException(model_id)


### PR DESCRIPTION
## 📝 Description

Leftover from https://github.com/open-edge-platform/geti/pull/376.

Use model entity to retrieve configuration when `model_id` is provided.

JIRA: ITEP-68215

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [x] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [x] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
