### PR TITLE
ITEP-67071 chore: Use FEATURE_FLAG_TELEMETRY_STACK to enable or disable telemetry

### DIFF
--- a/web_ui/src/analytics/analytics-provider.component.tsx
+++ b/web_ui/src/analytics/analytics-provider.component.tsx
@@ -7,6 +7,7 @@ import { useApplicationServices } from '@geti/core/src/services/application-serv
 import { Meter } from '@opentelemetry/api';
 import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 
+import { useFeatureFlags } from '../core/feature-flags/hooks/use-feature-flags.hook';
 import { useWorkflowId } from '../core/platform-utils/hooks/use-platform-utils.hook';
 import { useEventListener } from '../hooks/event-listener/event-listener.hook';
 import { createPeriodicMetricExporter, initializeMetrics } from './metrics';
@@ -106,8 +107,9 @@ const useAnalytics = (): AnalyticsContextProps => {
 };
 
 const useIsAnalyticsEnabled = (): boolean => {
-    // TODO: Implement a more robust check for analytics enablement
-    return true;
+    const { FEATURE_FLAG_TELEMETRY_STACK } = useFeatureFlags();
+
+    return FEATURE_FLAG_TELEMETRY_STACK;
 };
 
 export { AnalyticsProvider, useAnalytics, useIsAnalyticsEnabled };

--- a/web_ui/src/core/feature-flags/services/feature-flag-service.interface.ts
+++ b/web_ui/src/core/feature-flags/services/feature-flag-service.interface.ts
@@ -35,6 +35,7 @@ export const DEV_FEATURE_FLAGS = {
     FEATURE_FLAG_MANAGE_USERS_ROLES: false,
     FEATURE_FLAG_REQ_ACCESS: false,
     FEATURE_FLAG_NEW_CONFIGURABLE_PARAMETERS: false,
+    FEATURE_FLAG_TELEMETRY_STACK: true,
 
     // Only used for unit testing
     DEBUG: false,


### PR DESCRIPTION
## 📝 Description

This PR provides a logic for disabling the telemetry from the UI. While performing installation, flag will be propagated to feature flags and based on that FF we will decide whether we want to use telemetry or not.

Env to verify the changes work: https://10.55.252.140

JIRA: ITEP-67071

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🔨 **Refactor** – Non-breaking change which refactors the code base

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [X] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and descriptive
- [X] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
