### PR TITLE
ITEP-32138 Use training configuration for subset splitting [PART 1]

### DIFF
--- a/web_ui/src/core/configurable-parameters/hooks/use-training-configuration.hook.ts
+++ b/web_ui/src/core/configurable-parameters/hooks/use-training-configuration.hook.ts
@@ -2,7 +2,7 @@
 // LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 
 import { useApplicationServices } from '@geti/core/src/services/application-services-provider.component';
-import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import QUERY_KEYS from '../../../../packages/core/src/requests/query-keys';
@@ -23,6 +23,7 @@ const trainingConfigurationQueryOptions = (
         queryFn: () => {
             return service.getTrainingConfiguration(projectIdentifier, queryParameters);
         },
+        placeholderData: keepPreviousData,
     });
 
 export const useTrainingConfigurationQuery = (

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/advanced-settings.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/advanced-settings.component.tsx
@@ -6,6 +6,7 @@ import { FC, ReactNode } from 'react';
 import { Item, TabList, TabPanels, Tabs, Text, View } from '@geti/ui';
 
 import { ConfigurableParametersTaskChain } from '../../../../../../core/configurable-parameters/services/configurable-parameters.interface';
+import { TrainingConfiguration } from '../../../../../../core/configurable-parameters/services/configuration.interface';
 import { SupportedAlgorithm } from '../../../../../../core/supported-algorithms/supported-algorithms.interface';
 import { DataManagement } from './data-management/data-management.component';
 import { ModelArchitectures } from './model-architectures/model-architectures.component';
@@ -33,6 +34,7 @@ interface AdvancedSettingsProps {
     isReshufflingSubsetsEnabled: boolean;
     onReshufflingSubsetsEnabledChange: (reshufflingSubsetsEnabled: boolean) => void;
     configParameters: ConfigurableParametersTaskChain;
+    trainingConfiguration: TrainingConfiguration;
     trainFromScratch: boolean;
     onTrainFromScratchChange: (trainFromScratch: boolean) => void;
 }
@@ -52,6 +54,7 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
     onReshufflingSubsetsEnabledChange,
     trainFromScratch,
     onTrainFromScratchChange,
+    trainingConfiguration,
 }) => {
     const TABS: TabProps[] = [
         {
@@ -67,7 +70,7 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
         },
         {
             name: 'Data management',
-            children: <DataManagement configParameters={configParameters} />,
+            children: <DataManagement trainingConfiguration={trainingConfiguration} />,
         },
         {
             name: 'Training',

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/advanced-settings.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/advanced-settings.component.tsx
@@ -35,6 +35,9 @@ interface AdvancedSettingsProps {
     onReshufflingSubsetsEnabledChange: (reshufflingSubsetsEnabled: boolean) => void;
     configParameters: ConfigurableParametersTaskChain;
     trainingConfiguration: TrainingConfiguration;
+    onUpdateTrainingConfiguration: (
+        updateFunction: (config: TrainingConfiguration | undefined) => TrainingConfiguration | undefined
+    ) => void;
     trainFromScratch: boolean;
     onTrainFromScratchChange: (trainFromScratch: boolean) => void;
 }
@@ -55,6 +58,7 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
     trainFromScratch,
     onTrainFromScratchChange,
     trainingConfiguration,
+    onUpdateTrainingConfiguration,
 }) => {
     const TABS: TabProps[] = [
         {
@@ -70,7 +74,12 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
         },
         {
             name: 'Data management',
-            children: <DataManagement trainingConfiguration={trainingConfiguration} />,
+            children: (
+                <DataManagement
+                    trainingConfiguration={trainingConfiguration}
+                    onUpdateTrainingConfiguration={onUpdateTrainingConfiguration}
+                />
+            ),
         },
         {
             name: 'Training',

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/data-management.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/data-management.component.tsx
@@ -4,30 +4,35 @@
 import { FC } from 'react';
 
 import { View } from '@geti/ui';
+import { isEmpty } from 'lodash-es';
 
-import { ConfigurableParametersTaskChain } from '../../../../../../../core/configurable-parameters/services/configurable-parameters.interface';
+import { TrainingConfiguration } from '../../../../../../../core/configurable-parameters/services/configuration.interface';
 import { DataAugmentation } from './data-augmentation/data-augmentation.component';
 import { Filters } from './filters/filters.component';
 import { Tiling } from './tiling/tiling.component';
 import { TrainingSubsets } from './training-subsets/training-subsets.component';
 
 interface DataManagementProps {
-    configParameters: ConfigurableParametersTaskChain;
+    trainingConfiguration: TrainingConfiguration;
 }
 
-const getTilingParameters = (configParameters: ConfigurableParametersTaskChain) => {
-    return configParameters.components.find((component) => component.header === 'Tiling');
+const getTilingParameters = (_configParameters: TrainingConfiguration) => {
+    return undefined;
 };
 
-export const DataManagement: FC<DataManagementProps> = ({ configParameters }) => {
-    const tilingParameters = getTilingParameters(configParameters);
+export const DataManagement: FC<DataManagementProps> = ({
+    trainingConfiguration,
+}) => {
+    const tilingParameters = getTilingParameters(trainingConfiguration);
 
     return (
         <View>
             {/* Not supported in v1 of training flow revamp <BalanceLabelsDistribution /> */}
-            <TrainingSubsets />
+            <TrainingSubsets
+                subsetsConfiguration={trainingConfiguration.datasetPreparation.subsetSplit}
+            />
             {tilingParameters !== undefined && <Tiling tilingParameters={tilingParameters} />}
-            <DataAugmentation />
+            {!isEmpty(trainingConfiguration.datasetPreparation.augmentation) && <DataAugmentation />}
             <Filters />
             {/* Not supported in v1 of training flow revamp <RemovingDuplicates /> */}
         </View>

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/data-management.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/data-management.component.tsx
@@ -14,6 +14,9 @@ import { TrainingSubsets } from './training-subsets/training-subsets.component';
 
 interface DataManagementProps {
     trainingConfiguration: TrainingConfiguration;
+    onUpdateTrainingConfiguration: (
+        updateFunction: (config: TrainingConfiguration | undefined) => TrainingConfiguration | undefined
+    ) => void;
 }
 
 const getTilingParameters = (_configParameters: TrainingConfiguration) => {
@@ -22,6 +25,7 @@ const getTilingParameters = (_configParameters: TrainingConfiguration) => {
 
 export const DataManagement: FC<DataManagementProps> = ({
     trainingConfiguration,
+    onUpdateTrainingConfiguration,
 }) => {
     const tilingParameters = getTilingParameters(trainingConfiguration);
 
@@ -30,6 +34,7 @@ export const DataManagement: FC<DataManagementProps> = ({
             {/* Not supported in v1 of training flow revamp <BalanceLabelsDistribution /> */}
             <TrainingSubsets
                 subsetsConfiguration={trainingConfiguration.datasetPreparation.subsetSplit}
+                onUpdateTrainingConfiguration={onUpdateTrainingConfiguration}
             />
             {tilingParameters !== undefined && <Tiling tilingParameters={tilingParameters} />}
             {!isEmpty(trainingConfiguration.datasetPreparation.augmentation) && <DataAugmentation />}

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/data-management.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/data-management.component.tsx
@@ -23,10 +23,7 @@ const getTilingParameters = (_configParameters: TrainingConfiguration) => {
     return undefined;
 };
 
-export const DataManagement: FC<DataManagementProps> = ({
-    trainingConfiguration,
-    onUpdateTrainingConfiguration,
-}) => {
+export const DataManagement: FC<DataManagementProps> = ({ trainingConfiguration, onUpdateTrainingConfiguration }) => {
     const tilingParameters = getTilingParameters(trainingConfiguration);
 
     return (

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/training-subsets.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/training-subsets.component.tsx
@@ -7,6 +7,10 @@ import { ActionButton, Flex, Grid, minmax, Text, View } from '@geti/ui';
 import { Refresh } from '@geti/ui/icons';
 import { noop } from 'lodash-es';
 
+import {
+    NumberParameter,
+    TrainingConfiguration,
+} from '../../../../../../../../core/configurable-parameters/services/configuration.interface';
 import { Accordion } from '../../ui/accordion/accordion.component';
 import { SubsetsDistributionSlider } from './subsets-distribution-slider/subsets-distribution-slider.component';
 
@@ -121,21 +125,34 @@ const SubsetsDistribution: FC<SubsetsDistributionProps> = ({
 
 const MAX_RATIO_VALUE = 100;
 
-// eslint-disable-next-line
+type SubsetsConfiguration = TrainingConfiguration['datasetPreparation']['subsetSplit'];
+
 interface TrainingSubsetsProps {
-    // TODO: get props for subsets distribution
+    subsetsConfiguration: SubsetsConfiguration;
 }
 
-export const TrainingSubsets: FC<TrainingSubsetsProps> = ({}) => {
-    const testSubsetCount = 20;
-    const trainingSubsetCount = 70;
-    const validationSubsetCount = 10;
-    const trainingSubsetRatioProp = 0.7 * 100;
-    const validationSubsetRatioProp = 0.1 * 100;
+const getSubsets = (subsetsConfiguration: SubsetsConfiguration) => {
+    const testSubset = subsetsConfiguration.find((parameter) => parameter.key === 'test') as NumberParameter;
+    const validationSubset = subsetsConfiguration.find(
+        (parameter) => parameter.key === 'validation'
+    ) as NumberParameter;
+    const trainingSubset = subsetsConfiguration.find((parameter) => parameter.key === 'training') as NumberParameter;
+
+    return {
+        trainingSubset,
+        validationSubset,
+        testSubset,
+    };
+};
+
+export const TrainingSubsets: FC<TrainingSubsetsProps> = ({
+    subsetsConfiguration,
+}) => {
+    const { trainingSubset, validationSubset, testSubset } = getSubsets(subsetsConfiguration);
 
     const [subsetsDistribution, setSubsetsDistribution] = useState<number[]>([
-        trainingSubsetRatioProp,
-        trainingSubsetRatioProp + validationSubsetRatioProp,
+        trainingSubset.value,
+        trainingSubset.value + validationSubset.value,
     ]);
 
     const trainingSubsetRatio = subsetsDistribution[0];
@@ -160,9 +177,9 @@ export const TrainingSubsets: FC<TrainingSubsetsProps> = ({}) => {
                 <SubsetsDistribution
                     subsetsDistribution={subsetsDistribution}
                     onSubsetsDistributionChange={setSubsetsDistribution}
-                    testSubsetCount={testSubsetCount}
-                    trainingSubsetCount={trainingSubsetCount}
-                    validationSubsetCount={validationSubsetCount}
+                    testSubsetCount={testSubset.value}
+                    trainingSubsetCount={trainingSubset.value}
+                    validationSubsetCount={validationSubset.value}
                     onSubsetsDistributionChangeEnd={noop}
                     onSubsetsDistributionReset={noop}
                 />

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/training-subsets.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/training-subsets.component.tsx
@@ -154,10 +154,7 @@ const getSubsets = (subsetsConfiguration: SubsetsConfiguration) => {
     };
 };
 
-export const TrainingSubsets: FC<TrainingSubsetsProps> = ({
-    subsetsConfiguration,
-    onUpdateTrainingConfiguration,
-}) => {
+export const TrainingSubsets: FC<TrainingSubsetsProps> = ({ subsetsConfiguration, onUpdateTrainingConfiguration }) => {
     const { trainingSubset, validationSubset, testSubset } = getSubsets(subsetsConfiguration);
 
     const [subsetsDistribution, setSubsetsDistribution] = useState<number[]>([

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
@@ -51,6 +51,7 @@ const TrainModelDialog: FC<TrainModelDialogProps> = ({ onClose, onSuccess, isAll
         changeTrainFromScratch,
         trainFromScratch,
         trainingConfiguration,
+        updateTrainingConfiguration,
     } = useTrainModelState();
 
     const { canTrainModel, numberOfRequiredAnnotations } = isAllowedToTrainModel(selectedTask);
@@ -98,6 +99,7 @@ const TrainModelDialog: FC<TrainModelDialogProps> = ({ onClose, onSuccess, isAll
                 ) : (
                     <AdvancedSettings
                         trainingConfiguration={trainingConfiguration}
+                        onUpdateTrainingConfiguration={updateTrainingConfiguration}
                         configParameters={configParameters}
                         selectedModelTemplateId={selectedModelTemplateId}
                         onChangeSelectedTemplateId={changeSelectedTemplateId}

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
@@ -50,6 +50,7 @@ const TrainModelDialog: FC<TrainModelDialogProps> = ({ onClose, onSuccess, isAll
         configParameters,
         changeTrainFromScratch,
         trainFromScratch,
+        trainingConfiguration,
     } = useTrainModelState();
 
     const { canTrainModel, numberOfRequiredAnnotations } = isAllowedToTrainModel(selectedTask);
@@ -83,7 +84,7 @@ const TrainModelDialog: FC<TrainModelDialogProps> = ({ onClose, onSuccess, isAll
             <Heading>Train Model</Heading>
             <Divider />
             <Content>
-                {isBasicMode || configParameters === undefined ? (
+                {isBasicMode || configParameters === undefined || trainingConfiguration === undefined ? (
                     <TrainModelBasic
                         selectedTask={selectedTask}
                         tasks={tasks}
@@ -96,6 +97,7 @@ const TrainModelDialog: FC<TrainModelDialogProps> = ({ onClose, onSuccess, isAll
                     />
                 ) : (
                     <AdvancedSettings
+                        trainingConfiguration={trainingConfiguration}
                         configParameters={configParameters}
                         selectedModelTemplateId={selectedModelTemplateId}
                         onChangeSelectedTemplateId={changeSelectedTemplateId}

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/use-train-model-state.hook.ts
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/use-train-model-state.hook.ts
@@ -1,18 +1,20 @@
 // Copyright (C) 2022-2025 Intel Corporation
 // LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { keepPreviousData } from '@tanstack/react-query';
 import { isEmpty, isNumber } from 'lodash-es';
 
 import { useConfigParameters } from '../../../../../core/configurable-parameters/hooks/use-config-parameters.hook';
 import { useTrainingConfigurationQuery } from '../../../../../core/configurable-parameters/hooks/use-training-configuration.hook';
+import { TrainingConfiguration } from '../../../../../core/configurable-parameters/services/configuration.interface';
 import { useFeatureFlags } from '../../../../../core/feature-flags/hooks/use-feature-flags.hook';
 import { TrainingBodyDTO } from '../../../../../core/models/dtos/train-model.interface';
 import { useModels } from '../../../../../core/models/hooks/use-models.hook';
 import { ModelsGroups } from '../../../../../core/models/models.interface';
 import { isActiveModel } from '../../../../../core/models/utils';
+import { ProjectIdentifier } from '../../../../../core/projects/core.interface';
 import { Task } from '../../../../../core/projects/task.interface';
 import { useTasksWithSupportedAlgorithms } from '../../../../../core/supported-algorithms/hooks/use-tasks-with-supported-algorithms';
 import { SupportedAlgorithm } from '../../../../../core/supported-algorithms/supported-algorithms.interface';
@@ -42,6 +44,33 @@ const getActiveModelTemplateId = (
     );
 };
 
+const useTrainingConfiguration = ({
+    projectIdentifier,
+    selectedTaskId,
+    selectedModelTemplateId,
+}: {
+    projectIdentifier: ProjectIdentifier;
+    selectedTaskId: string;
+    selectedModelTemplateId: string | null;
+}) => {
+    const { data } = useTrainingConfigurationQuery(projectIdentifier, {
+        modelManifestId: selectedModelTemplateId,
+        taskId: selectedTaskId,
+    });
+
+    const [trainingConfiguration, setTrainingConfiguration] = useState<TrainingConfiguration | undefined>(data);
+
+    useEffect(() => {
+        if (data === undefined) {
+            return;
+        }
+
+        setTrainingConfiguration(data);
+    }, [data]);
+
+    return [trainingConfiguration, setTrainingConfiguration] as const;
+};
+
 export const useTrainModelState = () => {
     const [mode, setMode] = useState<TrainModelMode>(TrainModelMode.BASIC);
 
@@ -63,12 +92,11 @@ export const useTrainModelState = () => {
 
     const isBasicMode = mode === TrainModelMode.BASIC;
 
-    const { data: trainingConfiguration } = useTrainingConfigurationQuery(projectIdentifier, {
-        modelManifestId: selectedModelTemplateId,
-        taskId: selectedTask.id,
+    const [trainingConfiguration, setTrainingConfiguration] = useTrainingConfiguration({
+        projectIdentifier,
+        selectedTaskId: selectedTask.id,
+        selectedModelTemplateId,
     });
-
-    console.log({ trainingConfiguration });
 
     const { useGetModelConfigParameters } = useConfigParameters(projectIdentifier);
     const { data: configParameters } = useGetModelConfigParameters(
@@ -140,5 +168,6 @@ export const useTrainModelState = () => {
         trainFromScratch,
         changeTrainFromScratch: handleTrainFromScratchChange,
         trainingConfiguration,
+        updateTrainingConfiguration: setTrainingConfiguration,
     } as const;
 };

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/use-train-model-state.hook.ts
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/use-train-model-state.hook.ts
@@ -7,6 +7,7 @@ import { keepPreviousData } from '@tanstack/react-query';
 import { isEmpty, isNumber } from 'lodash-es';
 
 import { useConfigParameters } from '../../../../../core/configurable-parameters/hooks/use-config-parameters.hook';
+import { useTrainingConfigurationQuery } from '../../../../../core/configurable-parameters/hooks/use-training-configuration.hook';
 import { useFeatureFlags } from '../../../../../core/feature-flags/hooks/use-feature-flags.hook';
 import { TrainingBodyDTO } from '../../../../../core/models/dtos/train-model.interface';
 import { useModels } from '../../../../../core/models/hooks/use-models.hook';
@@ -61,6 +62,11 @@ export const useTrainModelState = () => {
     const [selectedModelTemplateId, setSelectedModelTemplateId] = useState<string | null>(activeModelTemplateId);
 
     const isBasicMode = mode === TrainModelMode.BASIC;
+
+    const { data: trainingConfiguration } = useTrainingConfigurationQuery(projectIdentifier, {
+        modelManifestId: selectedModelTemplateId,
+        taskId: selectedTask.id,
+    });
 
     const { useGetModelConfigParameters } = useConfigParameters(projectIdentifier);
     const { data: configParameters } = useGetModelConfigParameters(
@@ -131,5 +137,6 @@ export const useTrainModelState = () => {
         configParameters,
         trainFromScratch,
         changeTrainFromScratch: handleTrainFromScratchChange,
+        trainingConfiguration,
     } as const;
 };

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/use-train-model-state.hook.ts
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/use-train-model-state.hook.ts
@@ -68,6 +68,8 @@ export const useTrainModelState = () => {
         taskId: selectedTask.id,
     });
 
+    console.log({ trainingConfiguration });
+
     const { useGetModelConfigParameters } = useConfigParameters(projectIdentifier);
     const { data: configParameters } = useGetModelConfigParameters(
         {


### PR DESCRIPTION
## 📝 Description

In this PR I use new `training_configuration` endpoint that returns parameters that can be configured for training.
This is the first part of many, will try to keep PRs as small as possible. For now we change the parameters locally, in one of the next PR I'll add a logic to update the server.

JIRA: ITEP-32138

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🔨 **Refactor** – Non-breaking change which refactors the code base

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [X] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and descriptive
- [X] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
