### PR TITLE
fix: Fix flickering training model dialog

### DIFF
--- a/web_ui/src/core/configurable-parameters/hooks/use-config-parameters.hook.ts
+++ b/web_ui/src/core/configurable-parameters/hooks/use-config-parameters.hook.ts
@@ -22,7 +22,7 @@ interface UseConfigParameters {
             modelTemplateId?: string | null;
             editable?: boolean;
         },
-        options?: Pick<UseQueryOptions<ConfigurableParametersTaskChain, AxiosError>, 'enabled'>
+        options?: Pick<UseQueryOptions<ConfigurableParametersTaskChain, AxiosError>, 'enabled' | 'placeholderData'>
     ) => UseQueryResult<ConfigurableParametersTaskChain, AxiosError>;
     reconfigureParametersMutation: UseMutationResult<void, AxiosError, ConfigurableParametersReconfigureDTO, unknown>;
 }

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/ui/accordion/accordion.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/ui/accordion/accordion.component.tsx
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 
 import styles from './accordion.module.scss';
 
-type DisclosureProps = Omit<ComponentProps<typeof Disclosure>, 'isQuiet'>;
+type DisclosureProps = Omit<ComponentProps<typeof Disclosure>, 'isQuiet' | 'defaultExpanded'>;
 type DisclosureTitleProps = ComponentProps<typeof DisclosureTitle>;
 type DisclosurePanelProps = ComponentProps<typeof DisclosurePanel>;
 
@@ -55,7 +55,9 @@ const AccordionWarning: FC<{ children: ReactNode }> = ({ children }) => {
 };
 
 export const Accordion = ({ UNSAFE_className, ...props }: DisclosureProps) => {
-    return <Disclosure isQuiet {...props} UNSAFE_className={clsx(UNSAFE_className, styles.accordion)} />;
+    return (
+        <Disclosure isQuiet defaultExpanded {...props} UNSAFE_className={clsx(UNSAFE_className, styles.accordion)} />
+    );
 };
 
 Accordion.Title = AccordionTitle;

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-basic.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-basic.component.tsx
@@ -34,12 +34,12 @@ export const TrainModelBasic: FC<TrainModelBasicProps> = ({
     isTaskChainProject,
 }) => {
     return (
-        <Flex direction={'column'} gap={'size-200'}>
+        <Flex direction={'column'} gap={'size-200'} height={'100%'}>
             {isTaskChainProject && (
                 <TaskSelection tasks={tasks} onTaskChange={onTaskChange} selectedTask={selectedTask} />
             )}
 
-            <View padding={'size-250'} backgroundColor={'gray-50'}>
+            <View padding={'size-250'} backgroundColor={'gray-50'} flex={1} minHeight={0}>
                 <Text UNSAFE_className={classes.title} marginBottom={'size-100'}>
                     Model type
                 </Text>

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
@@ -79,7 +79,7 @@ const TrainModelDialog: FC<TrainModelDialogProps> = ({ onClose, onSuccess, isAll
     }
 
     return (
-        <Dialog maxWidth={'100rem'} width={'80vw'} height={'80vh'}>
+        <Dialog maxWidth={'100rem'} width={'80vw'} height={isBasicMode ? undefined : '80vh'}>
             <Heading>Train Model</Heading>
             <Divider />
             <Content>

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
@@ -79,7 +79,7 @@ const TrainModelDialog: FC<TrainModelDialogProps> = ({ onClose, onSuccess, isAll
     }
 
     return (
-        <Dialog maxWidth={'100rem'} width={'80vw'}>
+        <Dialog maxWidth={'100rem'} width={'80vw'} height={'80vh'}>
             <Heading>Train Model</Heading>
             <Divider />
             <Content>

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/use-train-model-state.hook.ts
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/use-train-model-state.hook.ts
@@ -3,6 +3,7 @@
 
 import { useState } from 'react';
 
+import { keepPreviousData } from '@tanstack/react-query';
 import { isEmpty, isNumber } from 'lodash-es';
 
 import { useConfigParameters } from '../../../../../core/configurable-parameters/hooks/use-config-parameters.hook';
@@ -62,11 +63,16 @@ export const useTrainModelState = () => {
     const isBasicMode = mode === TrainModelMode.BASIC;
 
     const { useGetModelConfigParameters } = useConfigParameters(projectIdentifier);
-    const { data: configParameters } = useGetModelConfigParameters({
-        taskId: selectedTask.id,
-        modelTemplateId: selectedModelTemplateId,
-        editable: true,
-    });
+    const { data: configParameters } = useGetModelConfigParameters(
+        {
+            taskId: selectedTask.id,
+            modelTemplateId: selectedModelTemplateId,
+            editable: true,
+        },
+        {
+            placeholderData: keepPreviousData,
+        }
+    );
 
     const [isReshufflingSubsetsEnabled, setIsReshufflingSubsetsEnabled] = useState<boolean>(false);
     const [trainFromScratch, setTrainFromScratch] = useState<boolean>(false);


### PR DESCRIPTION
## 📝 Description

The issue was that when selecting new model template we requested a new configurable parameters (later it will be training configuration as well https://github.com/open-edge-platform/geti/pull/442) which caused remounting the advanced settings. Moreover this PR sets height for the dialog so we no longer have layout shift when going from basic to advanced settings.

![image](https://github.com/user-attachments/assets/7fc97f8e-d7db-4421-abd1-27f34e7b6ae9)

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🐞 **Bug fix** – Non-breaking change which fixes an issue

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [X] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
