### PR TITLE
chore: Remove task picker from advanced mode

### DIFF
--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/advanced-settings.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/advanced-settings.component.tsx
@@ -3,12 +3,10 @@
 
 import { FC, ReactNode } from 'react';
 
-import { Flex, Item, TabList, TabPanels, Tabs, Text, View } from '@geti/ui';
+import { Item, TabList, TabPanels, Tabs, Text, View } from '@geti/ui';
 
 import { ConfigurableParametersTaskChain } from '../../../../../../core/configurable-parameters/services/configurable-parameters.interface';
-import { Task } from '../../../../../../core/projects/task.interface';
 import { SupportedAlgorithm } from '../../../../../../core/supported-algorithms/supported-algorithms.interface';
-import { TaskSelection } from '../model-types/task-selection.component';
 import { DataManagement } from './data-management/data-management.component';
 import { ModelArchitectures } from './model-architectures/model-architectures.component';
 import { Training } from './training/training.component';
@@ -28,10 +26,6 @@ const ContentWrapper: FC<{ children: ReactNode }> = ({ children }) => {
 };
 
 interface AdvancedSettingsProps {
-    tasks: Task[];
-    selectedTask: Task;
-    onTaskChange: (task: Task) => void;
-    isTaskChainProject: boolean;
     algorithms: SupportedAlgorithm[];
     selectedModelTemplateId: string | null;
     onChangeSelectedTemplateId: (modelTemplateId: string | null) => void;
@@ -50,10 +44,6 @@ interface TabProps {
 
 export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
     configParameters,
-    tasks,
-    selectedTask,
-    onTaskChange,
-    isTaskChainProject,
     algorithms,
     selectedModelTemplateId,
     onChangeSelectedTemplateId,
@@ -98,26 +88,21 @@ export const AdvancedSettings: FC<AdvancedSettingsProps> = ({
     ].filter((tab) => tab.children !== undefined);
 
     return (
-        <Flex direction={'column'} gap={'size-100'} height={'100%'}>
-            {isTaskChainProject && (
-                <TaskSelection tasks={tasks} onTaskChange={onTaskChange} selectedTask={selectedTask} />
-            )}
-            <Tabs items={TABS} flex={1} UNSAFE_style={{ overflow: 'hidden' }}>
-                <TabList>
-                    {(tab: TabProps) => (
-                        <Item key={tab.name} textValue={tab.name}>
-                            <Text>{tab.name}</Text>
-                        </Item>
-                    )}
-                </TabList>
-                <TabPanels marginTop={'size-250'} UNSAFE_style={{ overflow: 'hidden' }}>
-                    {(tab: TabProps) => (
-                        <Item key={tab.name} textValue={tab.name}>
-                            <ContentWrapper>{tab.children}</ContentWrapper>
-                        </Item>
-                    )}
-                </TabPanels>
-            </Tabs>
-        </Flex>
+        <Tabs items={TABS} height={'100%'} UNSAFE_style={{ overflow: 'hidden' }}>
+            <TabList>
+                {(tab: TabProps) => (
+                    <Item key={tab.name} textValue={tab.name}>
+                        <Text>{tab.name}</Text>
+                    </Item>
+                )}
+            </TabList>
+            <TabPanels marginTop={'size-250'} UNSAFE_style={{ overflow: 'hidden' }}>
+                {(tab: TabProps) => (
+                    <Item key={tab.name} textValue={tab.name}>
+                        <ContentWrapper>{tab.children}</ContentWrapper>
+                    </Item>
+                )}
+            </TabPanels>
+        </Tabs>
     );
 };

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/train-model-dialog.component.tsx
@@ -97,10 +97,6 @@ const TrainModelDialog: FC<TrainModelDialogProps> = ({ onClose, onSuccess, isAll
                 ) : (
                     <AdvancedSettings
                         configParameters={configParameters}
-                        selectedTask={selectedTask}
-                        tasks={tasks}
-                        onTaskChange={changeTask}
-                        isTaskChainProject={isTaskChainProject}
                         selectedModelTemplateId={selectedModelTemplateId}
                         onChangeSelectedTemplateId={changeSelectedTemplateId}
                         algorithms={algorithms}


### PR DESCRIPTION
## 📝 Description

Based on discussion with Mariusz (and also previous training implementation) we don't need to show training picker for the user in advanced mode.

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🔨 **Refactor** – Non-breaking change which refactors the code base

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
