### PR TITLE
ITEP-69231: Thumbnail video generation fails [OSError]

### DIFF
--- a/interactive_ai/services/resource/app/usecases/media_uploaded_usecase.py
+++ b/interactive_ai/services/resource/app/usecases/media_uploaded_usecase.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2022-2025 Intel Corporation
 # LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 import logging
+from tempfile import NamedTemporaryFile
 from typing import Any
 
 from geti_kafka_tools import publish_event
@@ -114,21 +115,21 @@ class MediaUploadedUseCase:
                 thumbnail_binary_filename=Video.thumbnail_filename_by_video_id(video_id),
             )
 
-            tmp_thumbnail_video = thumbnail_binary_repo.create_path_for_temporary_file(
-                filename=data_binary_filename, make_unique=False
-            )
-            generate_thumbnail_video(
-                data_binary_url=url,
-                thumbnail_video_path=tmp_thumbnail_video,
-                video_width=video_information.width,
-                video_height=video_information.height,
-                default_thumbnail_size=DEFAULT_THUMBNAIL_SIZE,
-            )
-            thumbnail_binary_repo.save(
-                data_source=tmp_thumbnail_video,
-                remove_source=True,
-                dst_file_name=Video.thumbnail_video_filename_by_video_id(video_id),
-            )
+            with NamedTemporaryFile() as tmp_thumbnail_video:
+                logger.debug(f"Writing thumbnail video to {tmp_thumbnail_video.name}")
+
+                generate_thumbnail_video(
+                    data_binary_url=url,
+                    thumbnail_video_path=tmp_thumbnail_video.name,
+                    video_width=video_information.width,
+                    video_height=video_information.height,
+                    default_thumbnail_size=DEFAULT_THUMBNAIL_SIZE,
+                )
+                thumbnail_binary_repo.save(
+                    data_source=tmp_thumbnail_video.name,
+                    remove_source=True,
+                    dst_file_name=Video.thumbnail_video_filename_by_video_id(video_id),
+                )
             logger.debug(f"Video {video_id} has been successfully preprocessed")
         except Exception as ex:
             logger.error(f"Error occurred while preprocessing video {video_id}", exc_info=ex)

--- a/interactive_ai/services/resource/app/usecases/media_uploaded_usecase.py
+++ b/interactive_ai/services/resource/app/usecases/media_uploaded_usecase.py
@@ -1,7 +1,8 @@
 # Copyright (C) 2022-2025 Intel Corporation
 # LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 import logging
-from tempfile import NamedTemporaryFile
+import os
+from tempfile import TemporaryDirectory
 from typing import Any
 
 from geti_kafka_tools import publish_event
@@ -115,19 +116,19 @@ class MediaUploadedUseCase:
                 thumbnail_binary_filename=Video.thumbnail_filename_by_video_id(video_id),
             )
 
-            with NamedTemporaryFile() as tmp_thumbnail_video:
-                logger.debug(f"Writing thumbnail video to {tmp_thumbnail_video.name}")
+            with TemporaryDirectory() as tmp_directory:
+                tmp_thumbnail_video = os.path.join(tmp_directory, data_binary_filename)
+                logger.debug(f"Writing thumbnail video to {tmp_thumbnail_video}")
 
                 generate_thumbnail_video(
                     data_binary_url=url,
-                    thumbnail_video_path=tmp_thumbnail_video.name,
+                    thumbnail_video_path=tmp_thumbnail_video,
                     video_width=video_information.width,
                     video_height=video_information.height,
                     default_thumbnail_size=DEFAULT_THUMBNAIL_SIZE,
                 )
                 thumbnail_binary_repo.save(
-                    data_source=tmp_thumbnail_video.name,
-                    remove_source=True,
+                    data_source=tmp_thumbnail_video,
                     dst_file_name=Video.thumbnail_video_filename_by_video_id(video_id),
                 )
             logger.debug(f"Video {video_id} has been successfully preprocessed")

--- a/interactive_ai/services/resource/tests/unit/usecases/test_media_uploaded_usecase.py
+++ b/interactive_ai/services/resource/tests/unit/usecases/test_media_uploaded_usecase.py
@@ -158,13 +158,20 @@ class TestMediaUploadedUseCase:
             thumbnail_binary_filename="image_id_thumbnail.jpg",
         )
 
+    @patch("usecases.media_uploaded_usecase.NamedTemporaryFile")
     @patch.object(ThumbnailBinaryRepo, "__init__", new=mock_init)
     @patch.object(VideoBinaryRepo, "__init__", new=mock_init)
-    def test_on_video_uploaded(self) -> None:
+    def test_on_video_uploaded(self, mock_named_temporary_file) -> None:
         # Arrange
         frame_numpy = MagicMock()
         cropped_numpy = MagicMock()
         video_information = VideoInformation(fps=30, width=200, height=100, total_frames=100)
+
+        temp_file = MagicMock()
+        temp_file.name = "temporary_path"
+        temp_file_context = MagicMock()
+        temp_file_context.__enter__.return_value = temp_file
+        mock_named_temporary_file.return_value = temp_file_context
 
         # Act
         with (
@@ -177,9 +184,6 @@ class TestMediaUploadedUseCase:
             patch.object(VideoFrameReader, "get_frame_numpy", return_value=frame_numpy) as mock_get_frame_numpy,
             patch.object(Media2DFactory, "crop_to_thumbnail", return_value=cropped_numpy) as mock_crop_to_thumbnail,
             patch.object(Media2DFactory, "create_and_save_media_thumbnail") as mock_create_and_save_media_thumbnail,
-            patch.object(
-                ThumbnailBinaryRepo, "create_path_for_temporary_file", return_value="temporary_path"
-            ) as mock_create_path_for_temporary_file,
             patch(
                 "usecases.media_uploaded_usecase.generate_thumbnail_video",
                 return_value="thumbnail_video_path",
@@ -202,7 +206,7 @@ class TestMediaUploadedUseCase:
             media_numpy=cropped_numpy,
             thumbnail_binary_filename="video_id_thumbnail.jpg",
         )
-        mock_create_path_for_temporary_file.assert_called_once_with(filename="data_binary_filename", make_unique=False)
+        mock_named_temporary_file.assert_called_once_with()
         mock_generate_thumbnail_video.assert_called_once_with(
             data_binary_url="presigned_url",
             thumbnail_video_path="temporary_path",

--- a/interactive_ai/services/resource/tests/unit/usecases/test_media_uploaded_usecase.py
+++ b/interactive_ai/services/resource/tests/unit/usecases/test_media_uploaded_usecase.py
@@ -158,20 +158,19 @@ class TestMediaUploadedUseCase:
             thumbnail_binary_filename="image_id_thumbnail.jpg",
         )
 
-    @patch("usecases.media_uploaded_usecase.NamedTemporaryFile")
+    @patch("usecases.media_uploaded_usecase.TemporaryDirectory")
     @patch.object(ThumbnailBinaryRepo, "__init__", new=mock_init)
     @patch.object(VideoBinaryRepo, "__init__", new=mock_init)
-    def test_on_video_uploaded(self, mock_named_temporary_file) -> None:
+    def test_on_video_uploaded(self, mock_temporary_directory) -> None:
         # Arrange
         frame_numpy = MagicMock()
         cropped_numpy = MagicMock()
         video_information = VideoInformation(fps=30, width=200, height=100, total_frames=100)
 
-        temp_file = MagicMock()
-        temp_file.name = "temporary_path"
-        temp_file_context = MagicMock()
-        temp_file_context.__enter__.return_value = temp_file
-        mock_named_temporary_file.return_value = temp_file_context
+        temp_dir = "temporary_path"
+        temp_dir_context = MagicMock()
+        temp_dir_context.__enter__.return_value = temp_dir
+        mock_temporary_directory.return_value = temp_dir_context
 
         # Act
         with (
@@ -206,16 +205,15 @@ class TestMediaUploadedUseCase:
             media_numpy=cropped_numpy,
             thumbnail_binary_filename="video_id_thumbnail.jpg",
         )
-        mock_named_temporary_file.assert_called_once_with()
+        mock_temporary_directory.assert_called_once_with()
         mock_generate_thumbnail_video.assert_called_once_with(
             data_binary_url="presigned_url",
-            thumbnail_video_path="temporary_path",
+            thumbnail_video_path="temporary_path/data_binary_filename",
             video_width=200,
             video_height=100,
             default_thumbnail_size=256,
         )
         mock_save.assert_called_once_with(
-            data_source="temporary_path",
-            remove_source=True,
+            data_source="temporary_path/data_binary_filename",
             dst_file_name="video_id_thumbnail.mp4",
         )


### PR DESCRIPTION
## 📝 Description

Fixes the problem with usage of temp file\dir while generating minimized video (thumbnail video).
Instead of LocalStorageClient it uses now tempfile.TemporaryDirectory.

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
