### PR TITLE
ITEP-32138 Add dataset size from new training configuration [PART 6] 

### DIFF
--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/training-subsets.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/training-subsets.component.tsx
@@ -11,16 +11,16 @@ import {
     NumberParameter,
     TrainingConfiguration,
 } from '../../../../../../../../core/configurable-parameters/services/configuration.interface';
-import { isNumberParameter } from '../../../../../../../../core/configurable-parameters/utils';
 import { Accordion } from '../../ui/accordion/accordion.component';
 import { SubsetsDistributionSlider } from './subsets-distribution-slider/subsets-distribution-slider.component';
+import { getSubsetsSizes } from './utils';
 
 import styles from './training-subsets.module.scss';
 
 interface SubsetDistributionStatsProps {
-    trainingCount: number;
-    validationCount: number;
-    testCount: number;
+    trainingSize: number;
+    validationSize: number;
+    testSize: number;
 }
 
 const Tile: FC<{ color: string }> = ({ color }) => {
@@ -29,33 +29,33 @@ const Tile: FC<{ color: string }> = ({ color }) => {
     );
 };
 
-const SubsetDistributionStat: FC<{ count: number; color: string; title: string }> = ({ count, color, title }) => {
+const SubsetDistributionStat: FC<{ size: number; color: string; title: string }> = ({ size, color, title }) => {
     return (
         <Flex alignItems={'center'} gap={'size-50'}>
             <Tile color={color} />
             <Text>
-                {title}: {count}
+                {title}: {size}
             </Text>
         </Flex>
     );
 };
 
-const SubsetDistributionStats: FC<SubsetDistributionStatsProps> = ({ trainingCount, validationCount, testCount }) => {
+const SubsetDistributionStats: FC<SubsetDistributionStatsProps> = ({ trainingSize, validationSize, testSize }) => {
     return (
         <View gridArea={'counts'} backgroundColor={'static-gray-800'} borderRadius={'small'} padding={'size-100'}>
             <Flex alignItems={'center'} justifyContent={'space-between'} UNSAFE_className={styles.statsText}>
                 <Flex alignItems={'center'} gap={'size-200'}>
-                    <SubsetDistributionStat title={'Training'} color={'var(--training-subset)'} count={trainingCount} />
+                    <SubsetDistributionStat title={'Training'} color={'var(--training-subset)'} size={trainingSize} />
                     <SubsetDistributionStat
                         title={'Validation'}
                         color={'var(--validation-subset)'}
-                        count={validationCount}
+                        size={validationSize}
                     />
-                    <SubsetDistributionStat title={'Test'} color={'var(--test-subset)'} count={testCount} />
+                    <SubsetDistributionStat title={'Test'} color={'var(--test-subset)'} size={testSize} />
                 </Flex>
                 <Text>
                     <Text UNSAFE_className={styles.totalStats}>Total: </Text>
-                    {trainingCount + validationCount + testCount} media items
+                    {trainingSize + validationSize + testSize} media items
                 </Text>
             </Flex>
         </View>
@@ -115,9 +115,9 @@ const SubsetsDistribution: FC<SubsetsDistributionProps> = ({
                     <Refresh />
                 </ActionButton>
                 <SubsetDistributionStats
-                    testCount={testSubsetSize}
-                    trainingCount={trainingSubsetSize}
-                    validationCount={validationSubsetSize}
+                    testSize={testSubsetSize}
+                    trainingSize={trainingSubsetSize}
+                    validationSize={validationSubsetSize}
                 />
             </Grid>
         </View>
@@ -155,16 +155,6 @@ const getSubsets = (subsetsConfiguration: SubsetsConfiguration) => {
     };
 };
 
-const getDatasetSize = (subsetsConfiguration: SubsetsConfiguration): number => {
-    const datasetSize = subsetsConfiguration.find((parameter) => parameter.key === 'dataset_size');
-
-    if (isNumberParameter(datasetSize)) {
-        return datasetSize.value;
-    }
-
-    return 0;
-};
-
 export const TrainingSubsets: FC<TrainingSubsetsProps> = ({ subsetsConfiguration, onUpdateTrainingConfiguration }) => {
     const { trainingSubset, validationSubset } = getSubsets(subsetsConfiguration);
 
@@ -176,20 +166,6 @@ export const TrainingSubsets: FC<TrainingSubsetsProps> = ({ subsetsConfiguration
     const trainingSubsetRatio = subsetsDistribution[0];
     const validationSubsetRatio = subsetsDistribution[1] - trainingSubsetRatio;
     const testSubsetRatio = MAX_RATIO_VALUE - subsetsDistribution[1];
-
-    const getSubsetsSizes = () => {
-        const datasetSize = getDatasetSize(subsetsConfiguration);
-
-        const validationSubsetSize = Math.round(datasetSize * (validationSubsetRatio / 100));
-        const testSubsetSize = Math.round(datasetSize * (testSubsetRatio / 100));
-        const trainingSubsetSize = datasetSize - validationSubsetSize - testSubsetSize;
-
-        return {
-            trainingSubsetSize,
-            validationSubsetSize,
-            testSubsetSize,
-        };
-    };
 
     const handleUpdateSubsetsConfiguration = (values: number[]): void => {
         onUpdateTrainingConfiguration((config) => {
@@ -246,7 +222,11 @@ export const TrainingSubsets: FC<TrainingSubsetsProps> = ({ subsetsConfiguration
         });
     };
 
-    const { trainingSubsetSize, validationSubsetSize, testSubsetSize } = getSubsetsSizes();
+    const { trainingSubsetSize, validationSubsetSize, testSubsetSize } = getSubsetsSizes(
+        subsetsConfiguration,
+        validationSubsetRatio,
+        testSubsetRatio
+    );
 
     return (
         <Accordion>

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/training-subsets.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/training-subsets.component.tsx
@@ -11,6 +11,7 @@ import {
     NumberParameter,
     TrainingConfiguration,
 } from '../../../../../../../../core/configurable-parameters/services/configuration.interface';
+import { isNumberParameter } from '../../../../../../../../core/configurable-parameters/utils';
 import { Accordion } from '../../ui/accordion/accordion.component';
 import { SubsetsDistributionSlider } from './subsets-distribution-slider/subsets-distribution-slider.component';
 
@@ -62,9 +63,9 @@ const SubsetDistributionStats: FC<SubsetDistributionStatsProps> = ({ trainingCou
 };
 
 interface SubsetsDistributionProps {
-    trainingSubsetCount: number;
-    validationSubsetCount: number;
-    testSubsetCount: number;
+    trainingSubsetSize: number;
+    validationSubsetSize: number;
+    testSubsetSize: number;
     subsetsDistribution: number[];
     onSubsetsDistributionChange: (values: number[]) => void;
     onSubsetsDistributionChangeEnd: (values: number[]) => void;
@@ -73,9 +74,9 @@ interface SubsetsDistributionProps {
 
 const SubsetsDistribution: FC<SubsetsDistributionProps> = ({
     subsetsDistribution,
-    trainingSubsetCount,
-    testSubsetCount,
-    validationSubsetCount,
+    trainingSubsetSize,
+    testSubsetSize,
+    validationSubsetSize,
     onSubsetsDistributionChange,
     onSubsetsDistributionChangeEnd,
     onSubsetsDistributionReset,
@@ -114,9 +115,9 @@ const SubsetsDistribution: FC<SubsetsDistributionProps> = ({
                     <Refresh />
                 </ActionButton>
                 <SubsetDistributionStats
-                    testCount={testSubsetCount}
-                    trainingCount={trainingSubsetCount}
-                    validationCount={validationSubsetCount}
+                    testCount={testSubsetSize}
+                    trainingCount={trainingSubsetSize}
+                    validationCount={validationSubsetSize}
                 />
             </Grid>
         </View>
@@ -154,8 +155,18 @@ const getSubsets = (subsetsConfiguration: SubsetsConfiguration) => {
     };
 };
 
+const getDatasetSize = (subsetsConfiguration: SubsetsConfiguration): number => {
+    const datasetSize = subsetsConfiguration.find((parameter) => parameter.key === 'dataset_size');
+
+    if (isNumberParameter(datasetSize)) {
+        return datasetSize.value;
+    }
+
+    return 0;
+};
+
 export const TrainingSubsets: FC<TrainingSubsetsProps> = ({ subsetsConfiguration, onUpdateTrainingConfiguration }) => {
-    const { trainingSubset, validationSubset, testSubset } = getSubsets(subsetsConfiguration);
+    const { trainingSubset, validationSubset } = getSubsets(subsetsConfiguration);
 
     const [subsetsDistribution, setSubsetsDistribution] = useState<number[]>([
         trainingSubset.value,
@@ -165,6 +176,20 @@ export const TrainingSubsets: FC<TrainingSubsetsProps> = ({ subsetsConfiguration
     const trainingSubsetRatio = subsetsDistribution[0];
     const validationSubsetRatio = subsetsDistribution[1] - trainingSubsetRatio;
     const testSubsetRatio = MAX_RATIO_VALUE - subsetsDistribution[1];
+
+    const getSubsetsSizes = () => {
+        const datasetSize = getDatasetSize(subsetsConfiguration);
+
+        const validationSubsetSize = Math.round(datasetSize * (validationSubsetRatio / 100));
+        const testSubsetSize = Math.round(datasetSize * (testSubsetRatio / 100));
+        const trainingSubsetSize = datasetSize - validationSubsetSize - testSubsetSize;
+
+        return {
+            trainingSubsetSize,
+            validationSubsetSize,
+            testSubsetSize,
+        };
+    };
 
     const handleUpdateSubsetsConfiguration = (values: number[]): void => {
         onUpdateTrainingConfiguration((config) => {
@@ -221,6 +246,8 @@ export const TrainingSubsets: FC<TrainingSubsetsProps> = ({ subsetsConfiguration
         });
     };
 
+    const { trainingSubsetSize, validationSubsetSize, testSubsetSize } = getSubsetsSizes();
+
     return (
         <Accordion>
             <Accordion.Title>
@@ -239,9 +266,9 @@ export const TrainingSubsets: FC<TrainingSubsetsProps> = ({ subsetsConfiguration
                 <SubsetsDistribution
                     subsetsDistribution={subsetsDistribution}
                     onSubsetsDistributionChange={setSubsetsDistribution}
-                    testSubsetCount={testSubset.value}
-                    trainingSubsetCount={trainingSubset.value}
-                    validationSubsetCount={validationSubset.value}
+                    testSubsetSize={testSubsetSize}
+                    trainingSubsetSize={trainingSubsetSize}
+                    validationSubsetSize={validationSubsetSize}
                     onSubsetsDistributionChangeEnd={handleUpdateSubsetsConfiguration}
                     onSubsetsDistributionReset={handleSubsetsConfigurationReset}
                 />

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/training-subsets.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/training-subsets.component.tsx
@@ -140,7 +140,6 @@ const VALIDATION_SUBSET_KEY = 'validation';
 const TRAINING_SUBSET_KEY = 'training';
 
 const getSubsets = (subsetsConfiguration: SubsetsConfiguration) => {
-    const testSubset = subsetsConfiguration.find((parameter) => parameter.key === TEST_SUBSET_KEY) as NumberParameter;
     const validationSubset = subsetsConfiguration.find(
         (parameter) => parameter.key === VALIDATION_SUBSET_KEY
     ) as NumberParameter;
@@ -151,7 +150,6 @@ const getSubsets = (subsetsConfiguration: SubsetsConfiguration) => {
     return {
         trainingSubset,
         validationSubset,
-        testSubset,
     };
 };
 

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/utils.test.ts
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/utils.test.ts
@@ -1,0 +1,89 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+import { getMockedConfigurationParameter } from '../../../../../../../../test-utils/mocked-items-factory/mocked-configuration-parameters';
+import { getSubsetsSizes } from './utils';
+
+describe('getSubsetsSizes', () => {
+    const datasetSizeParameter = [
+        getMockedConfigurationParameter({
+            type: 'int',
+            value: 101,
+            key: 'dataset_size',
+        }),
+    ];
+
+    it('calculates subsets sizes for equal distribution', () => {
+        const validationRatio = 33;
+        const testRatio = 33;
+
+        const result = getSubsetsSizes(datasetSizeParameter, validationRatio, testRatio);
+
+        expect(result.trainingSubsetSize).toBe(35);
+        expect(result.validationSubsetSize).toBe(33);
+        expect(result.testSubsetSize).toBe(33);
+    });
+
+    it('returns correct sizes for zero validation and test ratios', () => {
+        const validationRatio = 0;
+        const testRatio = 0;
+
+        const result = getSubsetsSizes(datasetSizeParameter, validationRatio, testRatio);
+
+        expect(result.trainingSubsetSize).toBe(101);
+        expect(result.validationSubsetSize).toBe(0);
+        expect(result.testSubsetSize).toBe(0);
+    });
+
+    it('handles maximum test ratio correctly', () => {
+        const validationRatio = 0;
+        const testRatio = 100;
+
+        const result = getSubsetsSizes(datasetSizeParameter, validationRatio, testRatio);
+
+        expect(result.trainingSubsetSize).toBe(0);
+        expect(result.validationSubsetSize).toBe(0);
+        expect(result.testSubsetSize).toBe(101);
+    });
+
+    it('handles maximum validation ratio correctly', () => {
+        const validationRatio = 100;
+        const testRatio = 0;
+
+        const result = getSubsetsSizes(datasetSizeParameter, validationRatio, testRatio);
+
+        expect(result.trainingSubsetSize).toBe(0);
+        expect(result.validationSubsetSize).toBe(101);
+        expect(result.testSubsetSize).toBe(0);
+    });
+
+    it('returns zero sizes for zero dataset size', () => {
+        const zeroDatasetParameters = [
+            getMockedConfigurationParameter({
+                type: 'int',
+                value: 0,
+                key: 'dataset_size',
+            }),
+        ];
+
+        const validationRatio = 50;
+        const testRatio = 50;
+
+        const result = getSubsetsSizes(zeroDatasetParameters, validationRatio, testRatio);
+
+        expect(result.trainingSubsetSize).toBe(0);
+        expect(result.validationSubsetSize).toBe(0);
+        expect(result.testSubsetSize).toBe(0);
+    });
+
+    it('returns zero sizes when dataset size parameter is missing', () => {
+        const validationRatio = 50;
+        const testRatio = 50;
+
+        const result = getSubsetsSizes([], validationRatio, testRatio);
+
+        expect(result.trainingSubsetSize).toBe(0);
+        expect(result.validationSubsetSize).toBe(0);
+        expect(result.testSubsetSize).toBe(0);
+    });
+});

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/utils.ts
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/data-management/training-subsets/utils.ts
@@ -1,0 +1,35 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+import { TrainingConfiguration } from '../../../../../../../../core/configurable-parameters/services/configuration.interface';
+import { isNumberParameter } from '../../../../../../../../core/configurable-parameters/utils';
+
+type SubsetSplitParameters = TrainingConfiguration['datasetPreparation']['subsetSplit'];
+
+const getDatasetSize = (subsetSplitParameters: SubsetSplitParameters): number => {
+    const datasetSize = subsetSplitParameters.find((parameter) => parameter.key === 'dataset_size');
+
+    if (isNumberParameter(datasetSize)) {
+        return datasetSize.value;
+    }
+
+    return 0;
+};
+
+export const getSubsetsSizes = (
+    subsetSplitParameters: SubsetSplitParameters,
+    validationSubsetRatio: number,
+    testSubsetRatio: number
+) => {
+    const datasetSize = getDatasetSize(subsetSplitParameters);
+
+    const validationSubsetSize = Math.floor(datasetSize * (validationSubsetRatio / 100));
+    const testSubsetSize = Math.floor(datasetSize * (testSubsetRatio / 100));
+    const trainingSubsetSize = datasetSize - validationSubsetSize - testSubsetSize;
+
+    return {
+        trainingSubsetSize,
+        validationSubsetSize,
+        testSubsetSize,
+    };
+};

--- a/web_ui/src/test-utils/mocked-items-factory/mocked-configuration-parameters.ts
+++ b/web_ui/src/test-utils/mocked-items-factory/mocked-configuration-parameters.ts
@@ -1,7 +1,11 @@
 // Copyright (C) 2022-2025 Intel Corporation
 // LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 
-import { ProjectConfiguration } from '../../core/configurable-parameters/services/configuration.interface';
+import {
+    ConfigurationParameter,
+    ProjectConfiguration,
+    TrainingConfiguration,
+} from '../../core/configurable-parameters/services/configuration.interface';
 
 export const getMockedProjectConfiguration = (config: Partial<ProjectConfiguration> = {}): ProjectConfiguration => ({
     taskConfigs: [
@@ -63,3 +67,60 @@ export const getMockedProjectConfiguration = (config: Partial<ProjectConfigurati
     ],
     ...config,
 });
+
+export const getMockedTrainingConfiguration = (config: Partial<TrainingConfiguration> = {}): TrainingConfiguration => ({
+    training: [],
+    datasetPreparation: {
+        subsetSplit: [],
+        augmentation: {},
+        filtering: {},
+    },
+    taskId: '',
+    advancedConfiguration: undefined,
+    evaluation: [],
+    ...config,
+});
+
+export const getMockedConfigurationParameter = (
+    parameter: Partial<ConfigurationParameter> & Required<Pick<ConfigurationParameter, 'type'>> = {
+        type: 'float',
+    }
+): ConfigurationParameter => {
+    if (parameter.type === 'float' || parameter.type === 'int') {
+        return {
+            value: 0,
+            key: 'mocked_parameter',
+            name: 'Mocked Parameter',
+            maxValue: 100,
+            minValue: 0,
+            description: 'This is a mocked configuration parameter',
+            defaultValue: 50,
+            ...parameter,
+        };
+    }
+
+    if (parameter.type === 'bool') {
+        return {
+            value: false,
+            key: 'mocked_bool_parameter',
+            name: 'Mocked Bool Parameter',
+            description: 'This is a mocked boolean configuration parameter',
+            defaultValue: false,
+            ...parameter,
+        };
+    }
+
+    if (parameter.type === 'enum') {
+        return {
+            allowedValues: ['option1', 'option2'],
+            defaultValue: 'option1',
+            name: 'Mocked Enum Parameter',
+            description: 'This is a mocked enum configuration parameter',
+            value: 'option1',
+            key: 'mocked_enum_parameter',
+            ...parameter,
+        };
+    }
+
+    throw new Error(`Unsupported parameter type: ${parameter.type}`);
+};


### PR DESCRIPTION
## 📝 Description

This PR adds dataset size based on which we calculate sizes of each subsets. 

Env to test (but is broken, dataset size is always 0 there): https://10.55.252.21 + UI locally.

JIRA: ITEP-32138

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🚀 **New feature** – Non-breaking change which adds functionality

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [X] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and descriptive
- [X] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
