### PR TITLE
fix: separate chart packaging output directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-umbrella-chart: build-chart
 
 clean:
 	echo "Cleaning all projects..."	
-	@for dir in $(PROJECTS); do \
+	@for dir in $(PROJECTS) $(DISTRIB_CHARTS); do \
 		echo "Running make clean in $$dir..."; \
 		$(MAKE) -C $$dir clean; \
 	done

--- a/Makefile.build
+++ b/Makefile.build
@@ -4,7 +4,7 @@
 PACKAGABLE_SUBPROJECTS := $(shell find . -name "Chart.yaml.template" | xargs dirname | xargs dirname)
 
 .PHONY: clean
-clean: clean-go clean-python
+clean: clean-go clean-python clean-packagable
 
 .PHONY: clean-go
 clean-go:
@@ -13,6 +13,10 @@ clean-go:
 .PHONY: clean-python
 clean-python:
 	@$(call run_for_each,$(PY_SUBPROJECTS),Cleaning for Python component,clean)
+
+.PHONY: clean-packagable
+clean-packagable:
+	@$(call run_for_each,$(PACKAGABLE_SUBPROJECTS),Cleaning for packagable components,clean)
 
 .PHONY: build-image
 build-image: build-image-go build-image-python

--- a/Makefile.shared
+++ b/Makefile.shared
@@ -93,7 +93,7 @@ build-chart-default:
 	TAG=$(TAG) COMPONENT_NAME=$(COMPONENT_NAME) envsubst < ${CHART_BUILD_DIR}/Chart.yaml.template > ${CHART_BUILD_DIR}/Chart.yaml
 	rm "${CHART_BUILD_DIR}/Chart.yaml.template"
 	helm dependency update ${CHART_BUILD_DIR}
-	helm package ${CHART_BUILD_DIR} --version ${TAG} --destination ${CHART_BUILD_DIR}
+	helm package ${CHART_BUILD_DIR} --version ${TAG} --destination ${BUILD_DIR}
 
 lint-chart-default: build-chart
 	@echo "Running chart linter for component: ${COMPONENT_NAME}"
@@ -101,12 +101,14 @@ lint-chart-default: build-chart
 
 publish-chart-default: build-chart
 	@echo "Publishing chart for component: ${COMPONENT_NAME}"
-	helm push ${CHART_BUILD_DIR}/${COMPONENT_NAME}-${TAG}.tgz oci://${CHARTS_REGISTRY}
+	helm push ${BUILD_DIR}/${COMPONENT_NAME}-${TAG}.tgz oci://${CHARTS_REGISTRY}
 
 clean:
+	@echo "Removing: $(BUILD_DIR)"
+	rm -rf $(BUILD_DIR)
 	@if [ -n "$(CLEAN_DIRS)" ]; then \
         echo "Removing: $(CLEAN_DIRS)"; \
-        rm -rf $(CLEAN_DIRS) $(BUILD_DIR); \
+        rm -rf $(CLEAN_DIRS); \
     fi
 
 # To suppress warnings when overriding Makefile targets, declare the abstract targets as <name>-default


### PR DESCRIPTION
## 📝 Description

This PR prevents component chart archives from being included in umbrella charts by using dedicated output directories for helm package command.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
