### PR TITLE
ITEP 70558 hide reset password

### DIFF
--- a/platform/services/user_directory/chart/templates/virtual_service.yaml
+++ b/platform/services/user_directory/chart/templates/virtual_service.yaml
@@ -12,30 +12,6 @@ spec:
   http:
   - match:
     - uri:
-        regex: "/api/v[^/]*/users/request_password_reset/?"
-    {{- if $.Values.global.cors_policy.enabled }}
-    corsPolicy:
-      allowHeaders: {{- include "user-directory.appendToArray" (dict "sourceArray" $.Values.global.cors_policy.allowed_headers) | indent 6 }}
-      allowOrigins: {{- include "user-directory.formatKeyValuePair" (dict "sourceDict" $.Values.global.cors_policy.allowed_origins) | indent 6 }}
-      allowMethods: {{- include "user-directory.appendToArray" (dict "sourceArray" $.Values.global.cors_policy.allowed_methods) | indent 6 }}
-      maxAge: {{ .Values.global.cors_policy.max_age | quote }}
-      allowCredentials: {{ .Values.global.cors_policy.allow_credentials }}
-    {{- end }}
-    headers:
-      response:
-        set:
-          Cache-Control: "no-cache, no-store, max-age=0, must-revalidate"
-{{ .Values.global.security_headers | indent 10 }}
-        remove:
-{{ .Values.global.stripped_headers | indent 8 }}
-    timeout: 360s
-    route:
-    - destination:
-        host: {{ include "user-directory.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
-        port:
-          number: {{ .Values.port }}
-  - match:
-    - uri:
         regex: "/api/v[^/]*/users/reset_password/?"
     {{- if $.Values.global.cors_policy.enabled }}
     corsPolicy:

--- a/platform/services/user_directory/chart/templates/virtual_service.yaml
+++ b/platform/services/user_directory/chart/templates/virtual_service.yaml
@@ -13,7 +13,7 @@ spec:
 {{/* endpoint disabled due to a possibility of using it to takeover of Geti account via password request poisoning - see ITEP-70558*/}}
 {{/*  - match: */}}
 {{/*    - uri: */}}
-{{/*        regex: "/api/v[^/]*/users/request_password_reset/?" */}}
+{{/*        regex: "/api/v1/users/request_password_reset/?" */}}
 {{/*    {{- if $.Values.global.cors_policy.enabled }} */}}
 {{/*    corsPolicy: */}}
 {{/*      allowHeaders: {{- include "user-directory.appendToArray" (dict "sourceArray" $.Values.global.cors_policy.allowed_headers) | indent 6 }} */}}

--- a/platform/services/user_directory/chart/templates/virtual_service.yaml
+++ b/platform/services/user_directory/chart/templates/virtual_service.yaml
@@ -10,6 +10,31 @@ spec:
   gateways:
   - {{ .Values.global.istio_ingress_namespace }}/{{ .Values.global.istio_gateway_name }}
   http:
+{{/* endpoint disabled due to a possibility of using it to takeover of Geti account via password request poisoning - see ITEP-70558*/}}
+{{/*  - match: */}}
+{{/*    - uri: */}}
+{{/*        regex: "/api/v[^/]*/users/request_password_reset/?" */}}
+{{/*    {{- if $.Values.global.cors_policy.enabled }} */}}
+{{/*    corsPolicy: */}}
+{{/*      allowHeaders: {{- include "user-directory.appendToArray" (dict "sourceArray" $.Values.global.cors_policy.allowed_headers) | indent 6 }} */}}
+{{/*      allowOrigins: {{- include "user-directory.formatKeyValuePair" (dict "sourceDict" $.Values.global.cors_policy.allowed_origins) | indent 6 }} */}}
+{{/*      allowMethods: {{- include "user-directory.appendToArray" (dict "sourceArray" $.Values.global.cors_policy.allowed_methods) | indent 6 }} */}}
+{{/*      maxAge: {{ .Values.global.cors_policy.max_age | quote }} */}}
+{{/*      allowCredentials: {{ .Values.global.cors_policy.allow_credentials }} */}}
+{{/*    {{- end }} */}}
+{{/*    headers: */}}
+{{/*      response: */}}
+{{/*        set: */}}
+{{/*          Cache-Control: "no-cache, no-store, max-age=0, must-revalidate" */}}
+{{/*{{ .Values.global.security_headers | indent 10 }} */}}
+{{/*        remove: */}}
+{{/*{{ .Values.global.stripped_headers | indent 8 }} */}}
+{{/*    timeout: 360s */}}
+{{/*    route: */}}
+{{/*    - destination: */}}
+{{/*        host: {{ include "user-directory.name" . }}.{{ .Release.Namespace }}.svc.cluster.local */}}
+{{/*        port: */}}
+{{/*          number: {{ .Values.port }} */}}
   - match:
     - uri:
         regex: "/api/v[^/]*/users/reset_password/?"

--- a/web_ui/dex_templates/templates/password.html
+++ b/web_ui/dex_templates/templates/password.html
@@ -54,11 +54,6 @@
                           </div>
                         </div>
                       </div>
-                      {{ if eq ("isSMTPDefined" | extra) "true" }}
-                        <div class="loginBox__forgotPassword">
-                            <a href="/registration/forgot-password" id="forgot-password-id" class="loginBox__link">Forgot password?</a>
-                        </div>
-                      {{ end }}
                       <button tabindex="3" id="submit-login" class="spectrum-Button spectrum-Button--cta spectrum-Button--sizeL loginBox__btn" type="submit">
                         <span class="spectrum-Button-label" id="login-sign-in-btn">Sign In</span>
                       </button>

--- a/web_ui/dex_templates/templates/password.html
+++ b/web_ui/dex_templates/templates/password.html
@@ -54,6 +54,12 @@
                           </div>
                         </div>
                       </div>
+                      <!-- {/* Disabled temporarily: https://jira.devtools.intel.com/browse/ITEP-70558 */} -->
+                      <!-- {{ if eq ("isSMTPDefined" | extra) "true" }}
+                        <div class="loginBox__forgotPassword">
+                            <a href="/registration/forgot-password" id="forgot-password-id" class="loginBox__link">Forgot password?</a>
+                        </div>
+                      {{ end }} -->
                       <button tabindex="3" id="submit-login" class="spectrum-Button spectrum-Button--cta spectrum-Button--sizeL loginBox__btn" type="submit">
                         <span class="spectrum-Button-label" id="login-sign-in-btn">Sign In</span>
                       </button>

--- a/web_ui/src/routes/app-routes.component.tsx
+++ b/web_ui/src/routes/app-routes.component.tsx
@@ -22,7 +22,6 @@ import { SignUp } from '../pages/sign-up/sign-up.component';
 import { InstallationModeProvider } from '../providers/installation-mode-provider.component';
 import { TusUploadProvider } from '../providers/tus-upload-provider/tus-upload-provider.component';
 import { LicenseModal } from '../shared/components/license-modal/license-modal.component';
-import { ForgotPassword } from '../sign-up/pages/forgot-password/forgot-password.component';
 import { InvalidLink } from '../sign-up/pages/invalid-link/invalid-link.component';
 import { Registration } from '../sign-up/pages/registration/registration.component';
 import { ResetPassword } from '../sign-up/pages/reset-password/reset-password.component';
@@ -146,7 +145,8 @@ export const appRoutes = () => {
                 }
             >
                 <Route path={paths.register.signUp.pattern} element={<Registration />} />
-                <Route path={paths.register.forgotPassword.pattern} element={<ForgotPassword />} />
+                {/* Disabled temporarily: https://jira.devtools.intel.com/browse/ITEP-70558 */}
+                {/* <Route path={paths.register.forgotPassword.pattern} element={<ForgotPassword />} /> */}
                 <Route path={paths.register.resetPassword.pattern} element={<ResetPassword />} />
                 <Route path={paths.register.invalidLink.pattern} element={<InvalidLink />} />
                 <Route path={paths.register.userNotFound.pattern} element={<UserNotFound />} />

--- a/web_ui/tests/features/auth/registration/registration.spec.ts
+++ b/web_ui/tests/features/auth/registration/registration.spec.ts
@@ -15,7 +15,10 @@ test.describe('Registration', () => {
         await page.addInitScript(() => localStorage.clear());
     });
 
-    test('it will let the user request to reset their password', async ({ page, openApi, baseURL }) => {
+    {
+        /* Disabled temporarily: https://jira.devtools.intel.com/browse/ITEP-70558 */
+    }
+    test.skip('it will let the user request to reset their password', async ({ page, openApi, baseURL }) => {
         openApi.registerHandler('notFound', (c, res, ctx) => {
             if (c.request.path === '/users/request_password_reset') {
                 return res(ctx.status(200), ctx.json({ moi: 'houi' }));


### PR DESCRIPTION
## 📝 Description

Hiding the reset password option to avoid potential Geti's account takeover through reset password poisoning.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Check if the "Forgot password" option is not available on a Login screen when the smtp server has been defined during installation and if there is no possibility to call the /api/v1/users/request_password_reset endpoint.

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
