### PR TITLE
ITEP-70983 increasing memory requests and memory limit in hpa configuration

### DIFF
--- a/interactive_ai/services/jobs/chart/values.yaml
+++ b/interactive_ai/services/jobs/chart/values.yaml
@@ -40,7 +40,7 @@ microservice:
   resources:
     requests:
       cpu: 400m
-      memory: 200Mi
+      memory: 300Mi
     limits:
       memory: 500Mi
 
@@ -74,7 +74,7 @@ scheduler:
   resources:
     requests:
       cpu: 300m
-      memory: 300Mi
+      memory: 200Mi
     limits:
       memory: 500Mi
 

--- a/interactive_ai/services/jobs/chart/values.yaml
+++ b/interactive_ai/services/jobs/chart/values.yaml
@@ -55,7 +55,7 @@ microservice:
     minReplicas: 1
     maxReplicas: 20
     targetCPUUtilizationPercentage: 90
-    targetMemoryUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 90
 
   ingress:
     endpoints:
@@ -74,7 +74,7 @@ scheduler:
   resources:
     requests:
       cpu: 300m
-      memory: 200Mi
+      memory: 300Mi
     limits:
       memory: 500Mi
 


### PR DESCRIPTION
## 📝 Description

Previous settings of the HorizontalPodAutoscaler led to unjustified creation of new replicas of this pod - which caused abnormal consumption of resources. Within the PR I increased memory threshold in a definition of HorizontalPodAutoscaler to 90% and in parallel I increased the requests for memory to 300 MB. Both changes should significantly reduce a possibility of scaling up this pod when there is no such need.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

While using the platform (executing training jobs etc) observe behavior of the impt-jobs-ms pod. It should stay with 1 replica during normal usage of the application.

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
