### PR TITLE
ITEP-71044 - video-timeline

### DIFF
--- a/web_ui/src/pages/annotator/components/video-player/hooks/use-video-timeline-queries.test.ts
+++ b/web_ui/src/pages/annotator/components/video-player/hooks/use-video-timeline-queries.test.ts
@@ -1,0 +1,46 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+import { ShapeType } from '../../../../../core/annotations/shapetype.enum';
+import { getMockedAnnotation } from '../../../../../test-utils/mocked-items-factory/mocked-annotations';
+import { getMockedKeypointNode } from '../../../../../test-utils/mocked-items-factory/mocked-keypoint';
+import { getMockedLabel } from '../../../../../test-utils/mocked-items-factory/mocked-labels';
+import { selectLabelsOfFrame } from './use-video-timeline-queries.hook';
+
+describe('selectLabelsOfFrame', () => {
+    it('return labels associated with annotations', () => {
+        const labels = [
+            { ...getMockedLabel({ id: 'label-1' }), source: { userId: '321' } },
+            { ...getMockedLabel({ id: 'label-2' }), source: { userId: '231' } },
+        ];
+
+        const key = 20;
+        const handler = selectLabelsOfFrame(key, false);
+        const response = handler({ [key]: [getMockedAnnotation({ labels })] });
+
+        labels.forEach(({ id }) => {
+            expect(response.has(id)).toBe(true);
+        });
+    });
+
+    it('return labels for keypoint nodes in pose annotation', () => {
+        const key = 10;
+        const keypointLabels = [getMockedLabel({ id: 'keypoint-1' }), getMockedLabel({ id: 'keypoint-2' })];
+        const mockedKeypointAnnotation = getMockedAnnotation({
+            shape: {
+                shapeType: ShapeType.Pose,
+                points: [
+                    getMockedKeypointNode({ label: keypointLabels[0], x: 0, y: 0 }),
+                    getMockedKeypointNode({ label: keypointLabels[1], x: 10, y: 10 }),
+                ],
+            },
+        });
+
+        const handler = selectLabelsOfFrame(key, true);
+        const response = handler({ [key]: [mockedKeypointAnnotation] });
+
+        keypointLabels.forEach(({ id }) => {
+            expect(response.has(id)).toBe(true);
+        });
+    });
+});

--- a/web_ui/src/pages/annotator/components/video-player/video-annotator/video-frame-segment.component.tsx
+++ b/web_ui/src/pages/annotator/components/video-player/video-annotator/video-frame-segment.component.tsx
@@ -4,6 +4,8 @@
 import { Flex, useNumberFormatter, View } from '@geti/ui';
 
 import { Label } from '../../../../../core/labels/label.interface';
+import { isKeypointTask } from '../../../../../core/projects/utils';
+import { useTask } from '../../../providers/task-provider/task-provider.component';
 import { useVideoTimelineQueries } from '../hooks/use-video-timeline-queries.hook';
 
 import classes from './video-annotator.module.scss';
@@ -91,7 +93,9 @@ export const VideoFrameSegment = ({
     isLastFrame,
     isFirstFrame,
 }: VideoFrameSegmentProps): JSX.Element => {
-    const { annotationsQuery, predictionsQuery } = useVideoTimelineQueries(frameNumber);
+    const { tasks } = useTask();
+    const { annotationsQuery, predictionsQuery } = useVideoTimelineQueries(frameNumber, tasks.some(isKeypointTask));
+
     const annotatedLabels = annotationsQuery.data ?? new Set<string>();
     const predictedLabels = predictionsQuery.data ?? new Set<string>();
 


### PR DESCRIPTION
## 📝 Description

The video timeline component currently uses annotation label IDs to highlight whether the current frame contains annotations. However, for keypoint detection, we shouldn’t rely on the annotation label — we should use the labels of the individual points instead.

This PR updates the logic to check if the task is keypoint detection and, if so, returns the appropriate point labels instead.

ITEP-71044

https://github.com/user-attachments/assets/15e80d0a-2466-4889-bed3-86eb10e8d333





## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [x] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
