### PR TITLE
ITEP-71263 Build service version based on environment variable

### DIFF
--- a/web_ui/Dockerfile
+++ b/web_ui/Dockerfile
@@ -23,8 +23,10 @@ RUN npm run build:rest-openapi-spec
 FROM node:22.12-bookworm-slim@sha256:35531c52ce27b6575d69755c73e65d4468dba93a25644eed56dc12879cae9213 AS web_ui_deps
 
 ARG LOCATION=/home/app/web_ui/
-
 WORKDIR ${LOCATION}
+
+ARG GETI_VERSION=latest
+ENV GETI_VERSION=$GETI_VERSION
 
 COPY --link package.json ./
 COPY --link package-lock.json ./

--- a/web_ui/Dockerfile
+++ b/web_ui/Dockerfile
@@ -26,8 +26,8 @@ ARG LOCATION=/home/app/web_ui/
 WORKDIR ${LOCATION}
 
 # The `GETI_VERSION` variable is send by the UI when it submits telemetry data
-ARG GETI_VERSION=development
-ENV GETI_VERSION=$GETI_VERSION
+ARG REACT_APP_GETI_VERSION=development
+ENV REACT_APP_GETI_VERSION=$REACT_APP_GETI_VERSION
 
 COPY --link package.json ./
 COPY --link package-lock.json ./

--- a/web_ui/Dockerfile
+++ b/web_ui/Dockerfile
@@ -25,7 +25,8 @@ FROM node:22.12-bookworm-slim@sha256:35531c52ce27b6575d69755c73e65d4468dba93a256
 ARG LOCATION=/home/app/web_ui/
 WORKDIR ${LOCATION}
 
-ARG GETI_VERSION=latest
+# The `GETI_VERSION` variable is send by the UI when it submits telemetry data
+ARG GETI_VERSION=development
 ENV GETI_VERSION=$GETI_VERSION
 
 COPY --link package.json ./

--- a/web_ui/Makefile
+++ b/web_ui/Makefile
@@ -7,7 +7,7 @@ COMPONENT_NAME := web
 # build contexts for web-ui image
 DOCKER_BUILD_CONTEXT := --build-context docs_context=../docs \
 						--build-context api_context=../interactive_ai/services/api \
-                        --build-arg GETI_VERSION=${TAG}
+                        --build-arg REACT_APP_GETI_VERSION=${TAG}
 
 DOCKER_IMAGE_DESCRIPTION := Web UI for Geti
 

--- a/web_ui/Makefile
+++ b/web_ui/Makefile
@@ -6,7 +6,9 @@ include ../Makefile.shared
 COMPONENT_NAME := web
 # build contexts for web-ui image
 DOCKER_BUILD_CONTEXT := --build-context docs_context=../docs \
-						--build-context api_context=../interactive_ai/services/api
+						--build-context api_context=../interactive_ai/services/api \
+                        --build-arg GETI_VERSION=${TAG}
+
 DOCKER_IMAGE_DESCRIPTION := Web UI for Geti
 
 tests: test-unit test-component test-integration

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -1,12 +1,10 @@
 {
   "name": "geti-ui",
-  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "geti-ui",
-      "version": "2.12.0",
       "workspaces": [
         "packages/*"
       ],

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -1,6 +1,5 @@
 {
   "name": "geti-ui",
-  "version": "2.12.0",
   "engines": {
     "node": "22.12.0",
     "npm": "10.9.0"

--- a/web_ui/src/analytics/utils.ts
+++ b/web_ui/src/analytics/utils.ts
@@ -10,7 +10,7 @@ export interface ResourceInfo {
     workflowId: string;
 }
 
-const SERVICE_VERSION = process.env.GETI_VERSION ?? 'dev';
+const SERVICE_VERSION = process.env.GETI_VERSION ?? 'latest';
 const SERVICE_NAME = 'intel-geti';
 
 export const SERVICE_DEFAULT_INFO: Omit<ResourceInfo, 'workflowId'> = {

--- a/web_ui/src/analytics/utils.ts
+++ b/web_ui/src/analytics/utils.ts
@@ -10,7 +10,7 @@ export interface ResourceInfo {
     workflowId: string;
 }
 
-const SERVICE_VERSION = process.env.GETI_VERSION ?? 'latest';
+const SERVICE_VERSION = process.env.REACT_APP_GETI_VERSION ?? 'latest';
 const SERVICE_NAME = 'intel-geti';
 
 export const SERVICE_DEFAULT_INFO: Omit<ResourceInfo, 'workflowId'> = {

--- a/web_ui/src/analytics/utils.ts
+++ b/web_ui/src/analytics/utils.ts
@@ -4,15 +4,13 @@
 import { CSRF_HEADERS } from '@geti/core/src/services/security';
 import { OTLPExporterNodeConfigBase } from '@opentelemetry/otlp-exporter-base';
 
-import packageJson from '../../package.json';
-
 export interface ResourceInfo {
     serviceName: string;
     serviceVersion: string;
     workflowId: string;
 }
 
-const SERVICE_VERSION = packageJson.version;
+const SERVICE_VERSION = process.env.GETI_VERSION ?? 'dev';
 const SERVICE_NAME = 'intel-geti';
 
 export const SERVICE_DEFAULT_INFO: Omit<ResourceInfo, 'workflowId'> = {


### PR DESCRIPTION
## 📝 Description

We want the [Version](https://github.com/open-edge-platform/geti/blob/main/VERSION) file to be our source of truth when it comes to application versioning.
In the UI we used to use the version from our `package.json` when setting the service version for our open telemetry configuration. With this change instead of relying on a `package.json` we rely on a `GETI_VERSION` environment variable that needs to be passed at build time.

Note: atm I havne't added the `GETI_VERSION` to our build configuration yet as it isn't immediately clear to me how to  add this.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
