### PR TITLE
:fix: Update submit button tooltip alignment

### DIFF
--- a/web_ui/src/pages/annotator/components/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/web_ui/src/pages/annotator/components/secondary-toolbar/secondary-toolbar.component.tsx
@@ -145,7 +145,7 @@ export const SecondaryToolbar = ({ annotationToolContext }: ToolAnnotationContex
                         </TooltipTrigger>
                     )}
                     {hasSubmit && isActiveLearningMode && (
-                        <TooltipTrigger placement={'left'}>
+                        <TooltipTrigger placement={'right'}>
                             <SubmitButton
                                 key={'submit'}
                                 canSubmit={shouldSave}

--- a/web_ui/src/pages/annotator/components/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/web_ui/src/pages/annotator/components/secondary-toolbar/secondary-toolbar.component.tsx
@@ -145,7 +145,7 @@ export const SecondaryToolbar = ({ annotationToolContext }: ToolAnnotationContex
                         </TooltipTrigger>
                     )}
                     {hasSubmit && isActiveLearningMode && (
-                        <TooltipTrigger placement={'bottom'}>
+                        <TooltipTrigger placement={'left'}>
                             <SubmitButton
                                 key={'submit'}
                                 canSubmit={shouldSave}


### PR DESCRIPTION
## 📝 Description

Fix for https://github.com/intel-innersource/applications.ai.geti.geti-release/actions/runs/16158220302/job/45604799969 failing

* Submit button tooltip now shows the tooltip content on the right (as it should). This way it doesnt block any element. The test should not fail anyway with `{ force: true }` but regardless of the test, this tooltip is very annoying in its current position. So this change fixes both.

![Screenshot 2025-07-09 at 07 44 10](https://github.com/user-attachments/assets/b8d70da6-ae94-41c7-a0ea-19cc6b73ae8c)
![Screenshot 2025-07-09 at 07 44 19](https://github.com/user-attachments/assets/40cb088b-5676-491e-884e-1b211cb46171)



<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
