### PR TITLE
ITEP-71484 Add unit test to check that the tooltip is displayed after hovering Model score info button

### DIFF
--- a/web_ui/src/pages/project-details/components/project-test/test-details.test.tsx
+++ b/web_ui/src/pages/project-details/components/project-test/test-details.test.tsx
@@ -8,6 +8,7 @@ import { JobInfoStatus } from '../../../../core/tests/dtos/tests.interface';
 import { getMockedTest } from '../../../../core/tests/services/tests-utils';
 import { Test } from '../../../../core/tests/tests.interface';
 import { projectRender as render } from '../../../../test-utils/project-provider-render';
+import { checkTooltip } from '../../../../test-utils/utils';
 import { TestDetails } from './test-details.component';
 
 const inMemoryProjectService = createInMemoryProjectService();
@@ -35,6 +36,15 @@ const renderTestDetails = async (test?: Partial<Test> | undefined) => {
 
 describe('TestDetails', () => {
     const testName = 'mocked-test-name';
+
+    it('renders a tooltip when hovering on Model score info button', async () => {
+        await renderTestDetails();
+        const infoButton = await screen.findByRole('button', { name: /label-relation/i });
+
+        expect(infoButton).toBeVisible();
+
+        await checkTooltip(infoButton, /model score for every image/i);
+    });
 
     it('renders initial score (labelId null)', async () => {
         const initialScore = mockedScores[0].value * 100;


### PR DESCRIPTION
## 📝 Description

Couldn't reproduce the bug with displaying tooltip on Model score info button hover. Turned out it was a cache issue on reporter's side. I've added a unit test to verify it as well.

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: ITEP-71484


## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [x] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [x] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
