### PR TITLE
ITEP-71844 Remove data-folder creation side-effect

### DIFF
--- a/platform/services/installer/.gitignore
+++ b/platform/services/installer/.gitignore
@@ -1,0 +1,4 @@
+app/platform_logs
+app/tools
+platform_installer
+

--- a/platform/services/installer/app/commands/install.py
+++ b/platform/services/installer/app/commands/install.py
@@ -38,6 +38,7 @@ from cli_utils.platform_logs import configure_logging, create_logs_dir
 from cli_utils.spinner import click_spinner
 from configuration_models.install_config import InstallationConfig
 from constants.paths import (
+    DATA_FOLDER,
     K3S_INSTALLATION_MARK_FILEPATH,
     K3S_KUBECONFIG_PATH,
     OFFLINE_TOOLS_DIR,
@@ -56,9 +57,10 @@ from geti_controller.uninstall import uninstall_geti_controller_chart
 from k3s.detect_ip import get_first_public_ip, get_master_node_ip_address
 from k3s.install import K3SInstallationError, install_k3s
 from k3s.uninstall import uninstall_k3s
-from platform_utils.errors import DownloadSystemPackagesError, StepsError
+from platform_utils.errors import DownloadSystemPackagesError, PathCreationError, StepsError
 from platform_utils.install_system_packages import install_system_packages
 from platform_utils.management.state import InstallationHandlerState, cluster_info_dump
+from platform_utils.path import create_data_folder
 from texts.checks import (
     DNSChecksTexts,
     InternetConnectionChecksTexts,
@@ -210,7 +212,7 @@ def monitor_installation_progress(config: InstallationConfig) -> tuple[str, str]
     return status, message
 
 
-def execute_installation(config: InstallationConfig) -> None:  # noqa: C901, RUF100
+def execute_installation(config: InstallationConfig) -> None:  # noqa: C901, RUF100, PLR0915
     """
     Execute platform installation with passed configuration.
     """
@@ -218,6 +220,17 @@ def execute_installation(config: InstallationConfig) -> None:  # noqa: C901, RUF
 
     handler_state = InstallationHandlerState()
     set_custom_signal_handler(handler_state, config.data_folder.value)
+
+    data_folder_path = config.data_folder.value
+    if not os.path.exists(data_folder_path):
+        try:
+            click.echo(InstallCmdTexts.data_folder_creation_start.format(path=data_folder_path))
+            create_data_folder(data_folder_path)
+            click.secho(InstallCmdTexts.data_folder_creation_succeeded, fg="green")
+        except PathCreationError:
+            logger.exception("Error during data folder creation.")
+            click.secho(InstallCmdTexts.data_folder_creation_failed, fg="red")
+            sys.exit(1)
 
     try:
         click.echo(InstallCmdTexts.sys_pkgs_installing)
@@ -304,6 +317,7 @@ def display_final_confirmation(config: InstallationConfig) -> None:
     "--data-folder",
     type=click.Path(),
     callback=is_data_folder_valid,
+    default=DATA_FOLDER,
     help="Absolute path to directory where Geti data will be stored.",
 )
 @click.option(

--- a/platform/services/installer/app/platform_utils/errors.py
+++ b/platform/services/installer/app/platform_utils/errors.py
@@ -17,6 +17,12 @@ A module containing exceptions raised by checks functions.
 import subprocess
 
 
+class PathCreationError(Exception):
+    """
+    Error raised by function used to create path.
+    """
+
+
 class StepsError(subprocess.SubprocessError):
     """
     Error raised by steps function.

--- a/platform/services/installer/app/platform_utils/path.py
+++ b/platform/services/installer/app/platform_utils/path.py
@@ -9,22 +9,25 @@
 #
 # This software and the related documents are provided as is, with no express or implied warranties,
 # other than those that are expressly stated in the License.
-
+import logging
 import os
 
-from constants.paths import DATA_FOLDER
+from platform_utils.errors import PathCreationError
 from texts.validators import PathValidatorsTexts
-from validators.errors import ValidationError
+
+logger = logging.getLogger(__name__)
 
 
-def create_default_data_folder() -> None:
+def create_data_folder(path: str) -> None:
     """
     This function creates a directory with the specified path and sets its permissions to 750.
-    Raises ValidationError if the directory already exists or if there are permission issues.
+    Raises PathCreationError if the directory already exists or if there are permission issues.
     """
     try:
-        os.makedirs(DATA_FOLDER, mode=0o750)
+        os.makedirs(path, mode=0o750)
     except FileExistsError:
-        raise ValidationError(PathValidatorsTexts.path_already_exists.format(path=DATA_FOLDER))
+        logger.error("Directory already exists: %s", path)
+        raise PathCreationError(PathValidatorsTexts.path_already_exists.format(path=path))
     except PermissionError:
-        raise ValidationError(PathValidatorsTexts.path_permission_error.format(path=DATA_FOLDER))
+        logger.error("Permission denied for path: %s", path)
+        raise PathCreationError(PathValidatorsTexts.path_permission_error.format(path=path))

--- a/platform/services/installer/app/texts/install_command.py
+++ b/platform/services/installer/app/texts/install_command.py
@@ -28,6 +28,9 @@ class InstallCmdTexts:
     checks_error_message = "Pre-installation checks failed, aborting installation."
     execution_start_message = "Executing installation..."
     data_folder_location = "Path to the data storage: "
+    data_folder_creation_start = "Creating data folder: {path}"
+    data_folder_creation_succeeded = "Data folder created successfully"
+    data_folder_creation_failed = "Data folder creation failed. Look for errors in the log."
     selected_username = "Initial user: "
     selected_password = "Password for initial user: "  # noqa: S105
     custom_certificate_prompt = "Do you want to configure your custom SSL certificate?"

--- a/platform/services/installer/app/texts/validators.py
+++ b/platform/services/installer/app/texts/validators.py
@@ -39,9 +39,6 @@ class PathValidatorsTexts:
     """
 
     invalid_path = "Provided path {path} format is not correct. It must be an absolute path (e.g. {folder})."
-    path_not_exists = (
-        "Provided path {path} does not point to an existing folder. It must be an absolute path (e.g. {folder})."
-    )
     path_not_folder = "Provided path {path} does not point to a folder."
     path_already_exists = (
         "Cannot create {path}. Please delete the folder or use '--data-folder'"

--- a/platform/services/installer/app/validators/path.py
+++ b/platform/services/installer/app/validators/path.py
@@ -15,26 +15,29 @@ A module with validating functions for data folder path.
 """
 
 import os.path
-import re
 
 from click import BadParameter, Context, Parameter
 
 from constants.paths import DATA_FOLDER
-from platform_utils.path import create_default_data_folder
 from texts.validators import PathValidatorsTexts
 from validators.errors import ValidationError
 
 
-def is_path_valid(path: str):  # noqa: ANN201
+def is_path_is_absolute(path: str) -> None:
     """
-    Checks whether the path is absolute, is not empty, is a not a directory and does not exist.
+    Checks whether the given path is absolute.
+    Raises ValidationError if given path is not absolute.
+    """
+    if not os.path.isabs(path):
+        raise ValidationError(PathValidatorsTexts.invalid_path.format(path=path, folder=DATA_FOLDER))
+
+
+def is_path_valid(path: str) -> None:
+    """
+    Checks whether the existing path is absolute, is not empty, is a not a directory and does not exist.
     Raises ValidationError if given path is invalid.
     """
-    regex = re.compile(r"(^[\/].*$)")
-    if not re.fullmatch(regex, str(path)):
-        raise ValidationError(PathValidatorsTexts.invalid_path.format(path=path, folder=DATA_FOLDER))
-    if not os.path.exists(path):
-        raise ValidationError(PathValidatorsTexts.path_not_exists.format(path=path, folder=DATA_FOLDER))
+    is_path_is_absolute(path)
     if os.path.isfile(path):
         raise ValidationError(PathValidatorsTexts.path_not_folder.format(path=path))
     if os.listdir(path):
@@ -52,17 +55,17 @@ def is_data_folder_valid(context: Context, param: Parameter, value: str) -> str:
     value: Value of the parameter
     """
     try:
-        if not value:
-            create_default_data_folder()
-        else:
+        if os.path.exists(value):
             is_path_valid(value)
             if get_path_permissions(value)[-1] != "0":
                 raise ValidationError(
                     PathValidatorsTexts.invalid_permissions.format(path=value, permissions=get_path_permissions(value))
                 )
+        else:
+            is_path_is_absolute(value)
     except ValidationError as e:
         raise BadParameter(str(e))
-    return value if value else DATA_FOLDER
+    return value
 
 
 def get_path_permissions(path: str) -> str:


### PR DESCRIPTION
## 📝 Description

Function used to validate data_folder had an unexpected side-effect - when executed without a value (for example when using defaults), it created the folder at default location.

This fix changes data-folder location handling:
1. `--data-folder` argument is still optional, if not provided a default value of `/data` will be used
2. data-folder validation requires that:
    1. provided location does not exist and will be created with correct permissions during installation
    2. or provided location already exists, it's an **empty** directory with correct permissions
3.  During installation, if configured data-folder does not exist, it will be created.

JIRA: ITEP-71844

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
