### PR TITLE
Make geti shape types compatible with smart tool types

### DIFF
--- a/web_ui/packages/smart-tools/src/shared/interfaces.ts
+++ b/web_ui/packages/smart-tools/src/shared/interfaces.ts
@@ -31,13 +31,9 @@ export interface Polygon {
     readonly shapeType: 'polygon';
 }
 
-interface KeypointNode {
-    readonly x: number;
-    readonly y: number;
-    readonly isVisible: boolean;
-}
 export interface Pose {
-    readonly points: KeypointNode[];
+    // NOTE: this is not fully compatible with Geti's type
+    readonly points: Point[];
     readonly shapeType: 'pose';
 }
 

--- a/web_ui/packages/smart-tools/src/shared/interfaces.ts
+++ b/web_ui/packages/smart-tools/src/shared/interfaces.ts
@@ -20,8 +20,8 @@ export interface RotatedRect extends Point {
 }
 
 export interface Circle {
-    readonly cx: number;
-    readonly cy: number;
+    readonly x: number;
+    readonly y: number;
     readonly r: number;
     readonly shapeType: 'circle';
 }
@@ -31,7 +31,17 @@ export interface Polygon {
     readonly shapeType: 'polygon';
 }
 
-export type Shape = Rect | RotatedRect | Circle | Polygon;
+interface KeypointNode {
+    readonly x: number;
+    readonly y: number;
+    readonly isVisible: boolean;
+}
+export interface Pose {
+    readonly points: KeypointNode[];
+    readonly shapeType: 'pose';
+}
+
+export type Shape = Rect | RotatedRect | Circle | Polygon | Pose;
 export type ShapeType = Shape['shapeType'];
 
 export interface RegionOfInterest {

--- a/web_ui/src/core/annotations/intersection-over-union.test.ts
+++ b/web_ui/src/core/annotations/intersection-over-union.test.ts
@@ -3,9 +3,10 @@
 
 import { intersectionOverUnion } from './intersection-over-union';
 import { Rect } from './shapes.interface';
+import { ShapeType } from './shapetype.enum';
 
 describe('intersection-over-union', () => {
-    const rect = { shapeType: 1, x: 0, y: 0, width: 0, height: 0 };
+    const rect: Rect = { shapeType: ShapeType.Rect, x: 0, y: 0, width: 0, height: 0 };
     const testData: [Rect, Rect, number][] = [
         [{ ...rect, x: 0, y: 0, width: 50, height: 50 }, { ...rect, x: 25, y: 25, width: 50, height: 50 }, 0.14],
         [{ ...rect, x: 0, y: 0, width: 50, height: 50 }, { ...rect, x: 25, y: 0, width: 50, height: 50 }, 0.33],

--- a/web_ui/src/core/annotations/services/inference-service/api-inference-service.test.ts
+++ b/web_ui/src/core/annotations/services/inference-service/api-inference-service.test.ts
@@ -148,7 +148,7 @@ describe('API inference service', () => {
                             },
                         },
                     ],
-                    shape: { ...shapeResponse, shapeType: 1 },
+                    shape: { ...shapeResponse, shapeType: 'rect' },
                     zIndex: 0,
                 },
             ]);
@@ -192,7 +192,7 @@ describe('API inference service', () => {
                             ...annotationLabel,
                         },
                     ],
-                    shape: { shapeType: 1, ...roiShape },
+                    shape: { shapeType: 'rect', ...roiShape },
                     zIndex: 0,
                 },
             ]);
@@ -256,7 +256,7 @@ describe('API inference service', () => {
                                 y: polygonResponseOne.shape.points[0].y,
                             },
                         ],
-                        shapeType: 3,
+                        shapeType: 'polygon',
                     },
                     zIndex: 1,
                 },
@@ -279,7 +279,7 @@ describe('API inference service', () => {
                                 y: polygonResponseTwo.shape.points[0].y,
                             },
                         ],
-                        shapeType: 3,
+                        shapeType: 'polygon',
                     },
                     zIndex: 2,
                 },
@@ -298,7 +298,7 @@ describe('API inference service', () => {
                 ],
                 shape: {
                     points: null,
-                    type: 'POLYGON',
+                    type: 'polygon',
                 },
             };
 
@@ -445,7 +445,7 @@ describe('API inference service', () => {
                         shape: {
                             x: 0,
                             y: 0,
-                            type: '1',
+                            type: 'rect',
                             width: mockedImageMedia.metadata.width,
                             height: mockedImageMedia.metadata.height,
                         },
@@ -475,7 +475,7 @@ describe('API inference service', () => {
                     labelsId: firstMap.label_id,
                     roi: {
                         id: expect.any(String),
-                        shape: { type: '1', ...roiShape },
+                        shape: { type: 'rect', ...roiShape },
                     },
                 },
             ]);
@@ -551,7 +551,7 @@ describe('API inference service', () => {
                         shape: {
                             x: 0,
                             y: 0,
-                            type: '1',
+                            type: 'rect',
                             height: mockedImage.height,
                             width: mockedImage.width,
                         },

--- a/web_ui/src/core/annotations/services/inference-service/utils.test.ts
+++ b/web_ui/src/core/annotations/services/inference-service/utils.test.ts
@@ -67,7 +67,7 @@ describe('api-inference-service-utils', () => {
             isLocked: false,
             isSelected: false,
             labels: [label],
-            shape: { ...expectedShape, shapeType: 1 },
+            shape: { ...expectedShape, shapeType: 'rect' },
             zIndex: 0,
         };
 

--- a/web_ui/src/core/annotations/services/utils.test.ts
+++ b/web_ui/src/core/annotations/services/utils.test.ts
@@ -132,7 +132,7 @@ describe('annotation service utils', () => {
                 label_id: config.label_id,
                 roi: {
                     id: roiId,
-                    shape: { type: '1', ...roiConfig },
+                    shape: { type: 'rect', ...roiConfig },
                 },
             },
         ]);

--- a/web_ui/src/core/annotations/shapetype.enum.ts
+++ b/web_ui/src/core/annotations/shapetype.enum.ts
@@ -1,9 +1,9 @@
 // Copyright (C) 2022-2025 Intel Corporation
 // LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 export enum ShapeType {
-    RotatedRect,
-    Rect,
-    Circle,
-    Polygon,
-    Pose,
+    RotatedRect = 'rotated-rect',
+    Rect = 'rect',
+    Circle = 'circle',
+    Polygon = 'polygon',
+    Pose = 'pose',
 }

--- a/web_ui/src/pages/annotator/hooks/use-grabcut.hook.ts
+++ b/web_ui/src/pages/annotator/hooks/use-grabcut.hook.ts
@@ -13,7 +13,7 @@ import { AlgorithmType } from '../../../hooks/use-load-ai-webworker/algorithm.in
 import { useLoadAIWebworker } from '../../../hooks/use-load-ai-webworker/use-load-ai-webworker.hook';
 import { GrabcutToolType } from '../tools/grabcut-tool/grabcut-tool.enums';
 import { GrabcutData } from '../tools/grabcut-tool/grabcut-tool.interface';
-import { convertGetiShapeToToolShape, convertToolShapeToGetiShape } from '../tools/utils';
+import { convertToolShapeToGetiShape } from '../tools/utils';
 
 interface useGrabcutProps {
     onSuccess: (data: Polygon, variables: GrabcutData) => void;
@@ -30,7 +30,7 @@ const convertGetiDataToGrabcutData = (data: GrabcutData): ToolGrabcutData => {
     return {
         ...data,
         inOrder: data.activeTool === GrabcutToolType.ForegroundTool,
-        inputRect: convertGetiShapeToToolShape(data.inputRect),
+        inputRect: data.inputRect,
     };
 };
 

--- a/web_ui/src/pages/annotator/hooks/use-interactive-segmentation.hook.ts
+++ b/web_ui/src/pages/annotator/hooks/use-interactive-segmentation.hook.ts
@@ -11,7 +11,7 @@ import { AlgorithmType } from '../../../hooks/use-load-ai-webworker/algorithm.in
 import { useLoadAIWebworker } from '../../../hooks/use-load-ai-webworker/use-load-ai-webworker.hook';
 import { useAnnotationScene } from '../providers/annotation-scene-provider/annotation-scene-provider.component';
 import { RITMData, RITMResult } from '../tools/ritm-tool/ritm-tool.interface';
-import { convertGetiShapeTypeToToolShapeType, convertToolShapeToGetiShape } from '../tools/utils';
+import { convertToolShapeToGetiShape } from '../tools/utils';
 
 interface useInteractiveSegmentationProps {
     onSuccess: (result: RITMResult) => void;
@@ -79,7 +79,7 @@ export const useInteractiveSegmentation = ({
             cancelRequested.current = false;
             setIsDrawing(true);
 
-            return ritmInstance.current.execute(area, givenPoints, convertGetiShapeTypeToToolShapeType(outputShape));
+            return ritmInstance.current.execute(area, givenPoints, outputShape);
         },
 
         onError: showNotificationError,

--- a/web_ui/src/pages/annotator/tools/ssim-tool/util.ts
+++ b/web_ui/src/pages/annotator/tools/ssim-tool/util.ts
@@ -9,12 +9,7 @@ import { getBoundingBox } from '../../../../core/annotations/math';
 import { Rect, Shape } from '../../../../core/annotations/shapes.interface';
 import { ShapeType } from '../../../../core/annotations/shapetype.enum';
 import { DOMAIN } from '../../../../core/projects/core.interface';
-import {
-    convertGetiShapeToToolShape,
-    convertGetiShapeTypeToToolShapeType,
-    convertToolShapeToGetiShape,
-    isShapeWithinRoi,
-} from '../utils';
+import { convertGetiShapeTypeToToolShapeType, convertToolShapeToGetiShape, isShapeWithinRoi } from '../utils';
 import { RunSSIMProps, SSIMMatch } from './ssim-tool.interface';
 
 export const MAX_NUMBER_ITEMS = 500;
@@ -105,7 +100,7 @@ export const convertRunSSIMPropsToToolRunSSIMProps = (runSSIMProps: RunSSIMProps
             shapeType: 'rect',
         },
         shapeType: convertGetiShapeTypeToToolShapeType(runSSIMProps.shapeType),
-        existingAnnotations: runSSIMProps.existingAnnotations.map(convertGetiShapeToToolShape),
+        existingAnnotations: runSSIMProps.existingAnnotations,
     };
 };
 

--- a/web_ui/src/pages/annotator/tools/ssim-tool/util.ts
+++ b/web_ui/src/pages/annotator/tools/ssim-tool/util.ts
@@ -9,7 +9,7 @@ import { getBoundingBox } from '../../../../core/annotations/math';
 import { Rect, Shape } from '../../../../core/annotations/shapes.interface';
 import { ShapeType } from '../../../../core/annotations/shapetype.enum';
 import { DOMAIN } from '../../../../core/projects/core.interface';
-import { convertGetiShapeTypeToToolShapeType, convertToolShapeToGetiShape, isShapeWithinRoi } from '../utils';
+import { convertToolShapeToGetiShape, isShapeWithinRoi } from '../utils';
 import { RunSSIMProps, SSIMMatch } from './ssim-tool.interface';
 
 export const MAX_NUMBER_ITEMS = 500;
@@ -99,7 +99,7 @@ export const convertRunSSIMPropsToToolRunSSIMProps = (runSSIMProps: RunSSIMProps
             ...runSSIMProps.template,
             shapeType: 'rect',
         },
-        shapeType: convertGetiShapeTypeToToolShapeType(runSSIMProps.shapeType),
+        shapeType: runSSIMProps.shapeType,
         existingAnnotations: runSSIMProps.existingAnnotations,
     };
 };

--- a/web_ui/src/pages/annotator/tools/utils.test.ts
+++ b/web_ui/src/pages/annotator/tools/utils.test.ts
@@ -294,7 +294,7 @@ describe('annotator utils', () => {
         });
 
         it('should convert circle shape', () => {
-            const shape: ToolShape = { shapeType: 'circle', cx: 10, cy: 20, r: 5 };
+            const shape: ToolShape = { shapeType: 'circle', x: 10, y: 20, r: 5 };
             expect(convertToolShapeToGetiShape(shape)).toEqual({
                 shapeType: ShapeType.Circle,
                 x: 10,
@@ -395,8 +395,8 @@ describe('annotator utils', () => {
             };
             expect(convertGetiShapeToToolShape(shape)).toEqual({
                 shapeType: 'circle',
-                cx: 11,
-                cy: 22,
+                x: 11,
+                y: 22,
                 r: 33,
             });
         });

--- a/web_ui/src/pages/annotator/tools/utils.test.ts
+++ b/web_ui/src/pages/annotator/tools/utils.test.ts
@@ -9,7 +9,6 @@ import { Circle, Point, Rect, Shape } from '../../../core/annotations/shapes.int
 import { ShapeType } from '../../../core/annotations/shapetype.enum';
 import { getMockedAnnotation } from '../../../test-utils/mocked-items-factory/mocked-annotations';
 import {
-    convertGetiShapeToToolShape,
     convertGetiShapeTypeToToolShapeType,
     convertToolShapeToGetiShape,
     isInsideBoundingBox,
@@ -329,81 +328,6 @@ describe('annotator utils', () => {
         it('should throw error for unknown shape type', () => {
             // @ts-expect-error error is expected
             expect(() => convertGetiShapeTypeToToolShapeType('unknown')).toThrow('Unknown shape type');
-        });
-    });
-
-    describe('convertGetiShapeToToolShape', () => {
-        it('should convert Rect shape', () => {
-            const shape: Shape = {
-                shapeType: ShapeType.Rect,
-                x: 10,
-                y: 20,
-                width: 30,
-                height: 40,
-            };
-            expect(convertGetiShapeToToolShape(shape)).toEqual({
-                shapeType: 'rect',
-                x: 10,
-                y: 20,
-                width: 30,
-                height: 40,
-            });
-        });
-
-        it('should convert RotatedRect shape', () => {
-            const shape: Shape = {
-                shapeType: ShapeType.RotatedRect,
-                x: 5,
-                y: 6,
-                width: 7,
-                height: 8,
-                angle: 15,
-            };
-            expect(convertGetiShapeToToolShape(shape)).toEqual({
-                shapeType: 'rotated-rect',
-                x: 5,
-                y: 6,
-                width: 7,
-                height: 8,
-                angle: 15,
-            });
-        });
-
-        it('should convert Polygon shape', () => {
-            const shape: Shape = {
-                shapeType: ShapeType.Polygon,
-                points: [
-                    { x: 1, y: 2 },
-                    { x: 3, y: 4 },
-                ],
-            };
-            expect(convertGetiShapeToToolShape(shape)).toEqual({
-                shapeType: 'polygon',
-                points: [
-                    { x: 1, y: 2 },
-                    { x: 3, y: 4 },
-                ],
-            });
-        });
-
-        it('should convert Circle shape', () => {
-            const shape: Shape = {
-                shapeType: ShapeType.Circle,
-                x: 11,
-                y: 22,
-                r: 33,
-            };
-            expect(convertGetiShapeToToolShape(shape)).toEqual({
-                shapeType: 'circle',
-                x: 11,
-                y: 22,
-                r: 33,
-            });
-        });
-
-        it('should throw error for unknown shape type', () => {
-            // @ts-expect-error error is expected
-            expect(() => convertGetiShapeToToolShape({ shapeType: 'unknown' })).toThrow('Unknown shape type');
         });
     });
 });

--- a/web_ui/src/pages/annotator/tools/utils.test.ts
+++ b/web_ui/src/pages/annotator/tools/utils.test.ts
@@ -5,11 +5,10 @@ import { Shape as ToolShape } from '@geti/smart-tools/src/shared/interfaces';
 
 import { RegionOfInterest } from '../../../core/annotations/annotation.interface';
 import { BoundingBox } from '../../../core/annotations/math';
-import { Circle, Point, Rect, Shape } from '../../../core/annotations/shapes.interface';
+import { Circle, Point, Rect } from '../../../core/annotations/shapes.interface';
 import { ShapeType } from '../../../core/annotations/shapetype.enum';
 import { getMockedAnnotation } from '../../../test-utils/mocked-items-factory/mocked-annotations';
 import {
-    convertGetiShapeTypeToToolShapeType,
     convertToolShapeToGetiShape,
     isInsideBoundingBox,
     isPointWithinRoi,
@@ -305,29 +304,6 @@ describe('annotator utils', () => {
         it('should throw error for unknown shape type', () => {
             // @ts-expect-error error is expected
             expect(() => convertToolShapeToGetiShape({ shapeType: 'unknown' })).toThrow('Unknown shape type');
-        });
-    });
-
-    describe('convertGetiShapeTypeToToolShapeType', () => {
-        it('should convert Rect', () => {
-            expect(convertGetiShapeTypeToToolShapeType(ShapeType.Rect)).toBe('rect');
-        });
-
-        it('should convert RotatedRect', () => {
-            expect(convertGetiShapeTypeToToolShapeType(ShapeType.RotatedRect)).toBe('rotated-rect');
-        });
-
-        it('should convert Polygon', () => {
-            expect(convertGetiShapeTypeToToolShapeType(ShapeType.Polygon)).toBe('polygon');
-        });
-
-        it('should convert Circle', () => {
-            expect(convertGetiShapeTypeToToolShapeType(ShapeType.Circle)).toBe('circle');
-        });
-
-        it('should throw error for unknown shape type', () => {
-            // @ts-expect-error error is expected
-            expect(() => convertGetiShapeTypeToToolShapeType('unknown')).toThrow('Unknown shape type');
         });
     });
 });

--- a/web_ui/src/pages/annotator/tools/utils.ts
+++ b/web_ui/src/pages/annotator/tools/utils.ts
@@ -426,21 +426,6 @@ export const SENSITIVITY_SLIDER_TOOLTIP =
     'while lower numbers decrease it. Keep in mind that increased precision requires more computing power and time. ' +
     'Adding high-resolution images may further extend the annotation waiting time significantly.';
 
-export const convertGetiShapeTypeToToolShapeType = (shapeType: ShapeType): SmartToolsShapeType => {
-    switch (shapeType) {
-        case ShapeType.Rect:
-            return 'rect';
-        case ShapeType.RotatedRect:
-            return 'rotated-rect';
-        case ShapeType.Polygon:
-            return 'polygon';
-        case ShapeType.Circle:
-            return 'circle';
-        default:
-            throw new Error('Unknown shape type');
-    }
-};
-
 export function convertToolShapeToGetiShape(shape: ToolPolygon): Polygon;
 export function convertToolShapeToGetiShape(shape: ToolRect): Rect;
 export function convertToolShapeToGetiShape(shape: ToolRotatedRect): RotatedRect;

--- a/web_ui/src/pages/annotator/tools/utils.ts
+++ b/web_ui/src/pages/annotator/tools/utils.ts
@@ -478,12 +478,3 @@ export function convertToolShapeToGetiShape(shape: SmartToolsShape): Shape {
             throw new Error('Unknown shape type');
     }
 }
-
-export function convertGetiShapeToToolShape(shape: Polygon): ToolPolygon;
-export function convertGetiShapeToToolShape(shape: Rect): ToolRect;
-export function convertGetiShapeToToolShape(shape: RotatedRect): ToolRotatedRect;
-export function convertGetiShapeToToolShape(shape: Circle): ToolCircle;
-export function convertGetiShapeToToolShape(shape: Shape): SmartToolsShape;
-export function convertGetiShapeToToolShape(shape: Shape): SmartToolsShape {
-    return shape;
-}

--- a/web_ui/src/pages/annotator/tools/utils.ts
+++ b/web_ui/src/pages/annotator/tools/utils.ts
@@ -470,8 +470,8 @@ export function convertToolShapeToGetiShape(shape: SmartToolsShape): Shape {
         case 'circle':
             return {
                 shapeType: ShapeType.Circle,
-                x: shape.cx,
-                y: shape.cy,
+                x: shape.x,
+                y: shape.y,
                 r: shape.r,
             };
         default:
@@ -511,8 +511,8 @@ export function convertGetiShapeToToolShape(shape: Shape): SmartToolsShape {
         case ShapeType.Circle:
             return {
                 shapeType: 'circle',
-                cx: shape.x,
-                cy: shape.y,
+                x: shape.x,
+                y: shape.y,
                 r: shape.r,
             };
         default:

--- a/web_ui/src/pages/annotator/tools/utils.ts
+++ b/web_ui/src/pages/annotator/tools/utils.ts
@@ -485,37 +485,5 @@ export function convertGetiShapeToToolShape(shape: RotatedRect): ToolRotatedRect
 export function convertGetiShapeToToolShape(shape: Circle): ToolCircle;
 export function convertGetiShapeToToolShape(shape: Shape): SmartToolsShape;
 export function convertGetiShapeToToolShape(shape: Shape): SmartToolsShape {
-    switch (shape.shapeType) {
-        case ShapeType.Rect:
-            return {
-                shapeType: 'rect',
-                x: shape.x,
-                y: shape.y,
-                width: shape.width,
-                height: shape.height,
-            };
-        case ShapeType.RotatedRect:
-            return {
-                shapeType: 'rotated-rect',
-                x: shape.x,
-                y: shape.y,
-                width: shape.width,
-                height: shape.height,
-                angle: shape.angle,
-            };
-        case ShapeType.Polygon:
-            return {
-                shapeType: 'polygon',
-                points: shape.points,
-            };
-        case ShapeType.Circle:
-            return {
-                shapeType: 'circle',
-                x: shape.x,
-                y: shape.y,
-                r: shape.r,
-            };
-        default:
-            throw new Error('Unknown shape type');
-    }
+    return shape;
 }

--- a/web_ui/src/pages/annotator/tools/utils.ts
+++ b/web_ui/src/pages/annotator/tools/utils.ts
@@ -7,7 +7,6 @@ import Clipper from '@doodle3d/clipper-js';
 import type ClipperShape from '@doodle3d/clipper-js';
 import {
     Shape as SmartToolsShape,
-    ShapeType as SmartToolsShapeType,
     Circle as ToolCircle,
     Polygon as ToolPolygon,
     Rect as ToolRect,


### PR DESCRIPTION
## 📝 Description

This PR changes the values of our `ShapeType` to be string values that are equal to the relevant string types used by our `@geti/smart-tool` package. This makes it easier for us to switch between Geti's type and the smart tool package type (which we don't want to make aware of our enums as that adds a hard dependency to Geti).

Two important notes:
- To make the circle types compatible I had to revert the `x` to `cx` change. Perhaps later we can change our types to use `cx` and `cy` everywhere for both circle and rotated rects
- The `Pose` shape isn't fully compatible as we don't want to have the smart tool package to be aware of our label logic. See the last commit for some details

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
