### PR TITLE
:chore: Avoid notification trigger after the pull request is opened

### DIFF
--- a/.github/workflows/notify-teams.yml
+++ b/.github/workflows/notify-teams.yml
@@ -4,7 +4,7 @@ name: Notify Teams on UI PR Creation
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened]
     paths:
       - 'web_ui/**'
 
@@ -23,7 +23,7 @@ jobs:
               "@type": "MessageCard",
               "@context": "http://schema.org/extensions",
               "themeColor": "0076D7",
-              "title": `🔔 New UI Pull Request Created!`,
+              "title": `🔔 New Pull Request Created!`,
               "text": pr.body ? pr.body.substring(0, 300) : '_No description provided._',
               "sections": [{
                 "activityTitle": `**Title:** [${pr.title}](${pr.html_url})`,


### PR DESCRIPTION
## 📝 Description

* Pushing extra commits should not trigger a new notification

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
