### PR TITLE
refactor: Don't pass `task_id` as query parameter while updating `project_configuration`

### DIFF
--- a/web_ui/src/core/configurable-parameters/hooks/use-project-configuration.hook.ts
+++ b/web_ui/src/core/configurable-parameters/hooks/use-project-configuration.hook.ts
@@ -7,10 +7,7 @@ import { AxiosError } from 'axios';
 
 import QUERY_KEYS from '../../../../packages/core/src/requests/query-keys';
 import { ProjectIdentifier } from '../../projects/core.interface';
-import {
-    CreateApiModelConfigParametersService,
-    ProjectConfigurationQueryParameters,
-} from '../services/api-model-config-parameters-service';
+import { CreateApiModelConfigParametersService } from '../services/api-model-config-parameters-service';
 import {
     ConfigurationParameter,
     KeyValueParameter,
@@ -69,16 +66,15 @@ export const useProjectConfigurationMutation = () => {
         {
             projectIdentifier: ProjectIdentifier;
             payload: ProjectConfigurationUploadPayload;
-            queryParameters?: ProjectConfigurationQueryParameters;
         },
         {
             previousConfiguration?: ProjectConfiguration;
         }
     >({
-        mutationFn: ({ projectIdentifier, payload, queryParameters }) => {
-            return configParametersService.updateProjectConfiguration(projectIdentifier, payload, queryParameters);
+        mutationFn: ({ projectIdentifier, payload }) => {
+            return configParametersService.updateProjectConfiguration(projectIdentifier, payload);
         },
-        onMutate: async ({ projectIdentifier, payload, queryParameters }) => {
+        onMutate: async ({ projectIdentifier, payload }) => {
             const queryKey = projectConfigurationQueryOptions(configParametersService, projectIdentifier).queryKey;
             await queryClient.cancelQueries({
                 queryKey,
@@ -95,30 +91,26 @@ export const useProjectConfigurationMutation = () => {
             queryClient.setQueryData<ProjectConfiguration>(queryKey, () => {
                 const updatedConfiguration: ProjectConfiguration = {
                     taskConfigs: previousConfiguration.taskConfigs.map((taskConfig) => {
-                        if (taskConfig.taskId === queryParameters?.taskId || queryParameters?.taskId === undefined) {
-                            const payloadTaskConfig = payload.taskConfigs.find(
-                                (config) => config.taskId === taskConfig.taskId
-                            );
+                        const payloadTaskConfig = payload.taskConfigs.find(
+                            (config) => config.taskId === taskConfig.taskId
+                        );
 
-                            return {
-                                ...taskConfig,
-                                autoTraining:
-                                    payloadTaskConfig?.autoTraining === undefined
-                                        ? taskConfig.autoTraining
-                                        : getUpdatedParameters(payloadTaskConfig.autoTraining, taskConfig.autoTraining),
-                                training:
-                                    payloadTaskConfig?.training === undefined
-                                        ? taskConfig.training
-                                        : {
-                                              constraints: getUpdatedParameters(
-                                                  payloadTaskConfig.training.constraints,
-                                                  taskConfig.training.constraints
-                                              ),
-                                          },
-                            };
-                        }
-
-                        return taskConfig;
+                        return {
+                            ...taskConfig,
+                            autoTraining:
+                                payloadTaskConfig?.autoTraining === undefined
+                                    ? taskConfig.autoTraining
+                                    : getUpdatedParameters(payloadTaskConfig.autoTraining, taskConfig.autoTraining),
+                            training:
+                                payloadTaskConfig?.training === undefined
+                                    ? taskConfig.training
+                                    : {
+                                          constraints: getUpdatedParameters(
+                                              payloadTaskConfig.training.constraints,
+                                              taskConfig.training.constraints
+                                          ),
+                                      },
+                        };
                     }),
                 };
 

--- a/web_ui/src/core/configurable-parameters/services/api-model-config-parameters-service.ts
+++ b/web_ui/src/core/configurable-parameters/services/api-model-config-parameters-service.ts
@@ -44,8 +44,6 @@ export interface TrainedModelConfigurationQueryParameters {
     modelId: string;
 }
 
-export type ProjectConfigurationQueryParameters = { taskId?: string };
-
 export interface CreateApiModelConfigParametersService {
     /**
      * @deprecated Please use getTrainingConfiguration instead
@@ -71,8 +69,7 @@ export interface CreateApiModelConfigParametersService {
     getProjectConfiguration: (projectIdentifier: ProjectIdentifier) => Promise<ProjectConfiguration>;
     updateProjectConfiguration: (
         projectIdentifier: ProjectIdentifier,
-        payload: ProjectConfigurationUploadPayload,
-        queryParameters?: ProjectConfigurationQueryParameters
+        payload: ProjectConfigurationUploadPayload
     ) => Promise<void>;
 
     getTrainingConfiguration: (
@@ -184,16 +181,11 @@ export const createApiModelConfigParametersService: CreateApiService<CreateApiMo
 
     const updateProjectConfiguration: CreateApiModelConfigParametersService['updateProjectConfiguration'] = async (
         projectIdentifier,
-        payload,
-        queryParameters
+        payload
     ) => {
         const payloadDTO = getProjectConfigurationUploadPayloadDTO(payload);
 
-        await instance.patch(router.CONFIGURATION.PROJECT(projectIdentifier), payloadDTO, {
-            params: {
-                task_id: queryParameters?.taskId,
-            },
-        });
+        await instance.patch(router.CONFIGURATION.PROJECT(projectIdentifier), payloadDTO);
     };
 
     return {

--- a/web_ui/src/shared/components/header/active-learning-configuration/use-active-learning-configuration.hook.ts
+++ b/web_ui/src/shared/components/header/active-learning-configuration/use-active-learning-configuration.hook.ts
@@ -30,76 +30,59 @@ export const useActiveLearningConfiguration = (
 
     const projectConfigurationMutation = useProjectConfigurationMutation();
     const notCropTasks = tasks.filter(isNotCropTask);
-    const istTaskChain = notCropTasks.length > 1;
 
-    const updateProjectConfiguration = ({
-        taskId,
-        payload,
-    }: {
-        taskId?: string;
-        payload: ProjectConfigurationUploadPayload;
-    }) => {
+    const updateProjectConfiguration = (payload: ProjectConfigurationUploadPayload) => {
         projectConfigurationMutation.mutate({
             projectIdentifier,
             payload,
-            queryParameters: istTaskChain ? { taskId } : undefined,
         });
     };
 
     const updateAutoTraining = (taskId: string, value: boolean) => {
         updateProjectConfiguration({
-            taskId,
-            payload: {
-                taskConfigs: [
-                    {
-                        taskId,
-                        autoTraining: [
-                            {
-                                key: 'enable',
-                                value,
-                            },
-                        ],
-                    },
-                ],
-            },
+            taskConfigs: [
+                {
+                    taskId,
+                    autoTraining: [
+                        {
+                            key: 'enable',
+                            value,
+                        },
+                    ],
+                },
+            ],
         });
     };
 
     const updateDynamicRequiredAnnotations = (taskId: string, value: boolean) => {
         updateProjectConfiguration({
-            taskId,
-            payload: {
-                taskConfigs: [
-                    {
-                        taskId,
-                        autoTraining: [
-                            {
-                                key: 'enable_dynamic_required_annotations',
-                                value,
-                            },
-                        ],
-                    },
-                ],
-            },
+            taskConfigs: [
+                {
+                    taskId,
+                    autoTraining: [
+                        {
+                            key: 'enable_dynamic_required_annotations',
+                            value,
+                        },
+                    ],
+                },
+            ],
         });
     };
 
     const updateRequiredImagesAutoTraining = (taskId: string, value: number) => {
         updateProjectConfiguration({
-            taskId,
-            payload: {
-                taskConfigs: [
-                    {
-                        taskId,
-                        autoTraining: [
-                            {
-                                key: 'min_images_per_label',
-                                value,
-                            },
-                        ],
-                    },
-                ],
-            },
+            taskConfigs: [
+                {
+                    taskId,
+                    autoTraining: [
+                        {
+                            key: 'min_images_per_label',
+                            value,
+                        },
+                    ],
+                },
+            ],
         });
     };
 


### PR DESCRIPTION
## 📝 Description

This PR removes sending `task_id` while updating `project_configuration`.

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🔨 **Refactor** – Non-breaking change which refactors the code base


## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [X] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
