### PR TITLE
fix: Don't hide use file/use camera while loading camera permissions

### DIFF
--- a/web_ui/src/pages/project-details/components/project-tests/quick-inference/live-camera-inference/live-camera-inference.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-tests/quick-inference/live-camera-inference/live-camera-inference.component.tsx
@@ -155,7 +155,7 @@ const LiveCameraInferenceContent = () => {
     const { userPermissions } = useDeviceSettings();
 
     if (isPermissionPending(userPermissions)) {
-        return <Loading aria-label='permissions pending' />;
+        return <Loading mode={'inline'} aria-label='permissions pending' style={{ height: '100%' }} />;
     }
 
     if (hasPermissionsDenied(userPermissions)) {


### PR DESCRIPTION
## 📝 Description

The issue was that when user switched to `Use camera`, the whole content of that tab, together with the `Use file/Use camera` was unmounted. This PR fixes that issue.

<!--  
If the PR addresses a specific GitHub issue, include one of the following lines to enable auto-closing:
Fixes #<issue_number>
Closes #<issue_number>

If referencing an internal ticket (e.g. JIRA), include the ticket number instead:
JIRA: <project-key>-<ticket-number>

If there’s no related issue or ticket, you can skip this section.
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🐞 **Bug fix** – Non-breaking change which fixes an issue

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and descriptive
- [ ] 📝 For internal contributors: If applicable, include the JIRA ticket number (e.g., ITEP-123456) in the PR **title**. Do **not** include full URLs
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
