### PR TITLE
Reduce dex_template container image size

### DIFF
--- a/web_ui/dex_templates/Dockerfile
+++ b/web_ui/dex_templates/Dockerfile
@@ -1,4 +1,4 @@
 # syntax=docker/dockerfile:1.7
-FROM scratch
+FROM debian:bookworm-slim@sha256:6ac2c08566499cc2415926653cf2ed7c3aedac445675a013cc09469c9e118fdd AS dex_templates
 
 COPY --link . /dex_templates/

--- a/web_ui/dex_templates/Dockerfile
+++ b/web_ui/dex_templates/Dockerfile
@@ -1,4 +1,4 @@
 # syntax=docker/dockerfile:1.7
-FROM docker.io/python:3.10-slim-bookworm@sha256:9dd6774a1276178f94b0cc1fb1f0edd980825d0ea7634847af9940b1b6273c13 AS dex_templates
+FROM scratch
 
 COPY --link . /dex_templates/


### PR DESCRIPTION
## 📝 Description
This PR reduces `dex_templates` container image size (48.5MB -> 29.3MB) by using `debian:bookworm-slim`.
Currently, we can not use `scratch` or `distroless` as `/bin/sh` and several other binaries are required by `dex_templates` image.

Closes #845


## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [x] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
