### PR TITLE
Added RGBA->RGB conversion while saving JPEG images

### DIFF
--- a/interactive_ai/services/resource/app/usecases/media_uploaded_usecase.py
+++ b/interactive_ai/services/resource/app/usecases/media_uploaded_usecase.py
@@ -79,9 +79,12 @@ class MediaUploadedUseCase:
             # Create a thumbnail for the image
             dst_file_name = Image.thumbnail_filename_by_image_id(image_id)
             with tempfile.NamedTemporaryFile(suffix=dst_file_name) as temp_file:
-                MediaUploadedUseCase.crop_to_thumbnail(
+                thumbnail_image = MediaUploadedUseCase.crop_to_thumbnail(
                     pil_image=pil_image, target_width=DEFAULT_THUMBNAIL_SIZE, target_height=DEFAULT_THUMBNAIL_SIZE
-                ).save(temp_file.name)
+                )
+                if thumbnail_image.mode in ("RGBA", "P"):
+                    thumbnail_image = thumbnail_image.convert("RGB")
+                thumbnail_image.save(temp_file.name)
                 ThumbnailBinaryRepo(dataset_storage_identifier).save(
                     data_source=temp_file.name, dst_file_name=dst_file_name
                 )


### PR DESCRIPTION
## 📝 Description

Fixes a problem with saving thumbnails or converted images (tiff -> jpeg) with RGBA channels.
JPEG/JPG doesn't support RGBA, so conversion is needed.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
