### PR TITLE
:bugfix: Hide learning params if training config is empty

### DIFF
--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/training/training.component.test.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/training/training.component.test.tsx
@@ -1,0 +1,62 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+import { screen } from '@testing-library/react';
+
+import { TrainingConfiguration } from '../../../../../../../core/configurable-parameters/services/configuration.interface';
+import { providersRender as render } from '../../../../../../../test-utils/required-providers-render';
+import { Training } from './training.component';
+
+const baseConfig: TrainingConfiguration = {
+    training: [
+        {
+            key: 'max_epochs',
+            name: 'Maximum epochs',
+            type: 'int',
+            description: 'Maximum number of training epochs to run',
+            value: 100,
+            defaultValue: 100,
+            minValue: 0,
+            maxValue: null,
+        },
+    ],
+    datasetPreparation: {
+        subsetSplit: [],
+        augmentation: {},
+        filtering: {},
+    },
+    taskId: '',
+    evaluation: [],
+};
+
+describe('Training component', () => {
+    it('renders LearningParameters if training parameters are not empty', () => {
+        render(
+            <Training
+                trainFromScratch={false}
+                onTrainFromScratchChange={jest.fn()}
+                trainingConfiguration={baseConfig}
+                onUpdateTrainingConfiguration={jest.fn()}
+                isReshufflingSubsetsEnabled={true}
+                onReshufflingSubsetsEnabledChange={jest.fn()}
+            />
+        );
+
+        expect(screen.getByLabelText('Learning parameters tag')).toBeInTheDocument();
+    });
+
+    it('does not render LearningParameters if training parameters are empty', () => {
+        render(
+            <Training
+                trainFromScratch={false}
+                onTrainFromScratchChange={jest.fn()}
+                trainingConfiguration={{ ...baseConfig, training: [] }}
+                onUpdateTrainingConfiguration={jest.fn()}
+                isReshufflingSubsetsEnabled={true}
+                onReshufflingSubsetsEnabledChange={jest.fn()}
+            />
+        );
+
+        expect(screen.queryByLabelText('Learning parameters tag')).not.toBeInTheDocument();
+    });
+});

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/training/training.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/training/training.component.tsx
@@ -4,6 +4,7 @@
 import { FC } from 'react';
 
 import { View } from '@geti/ui';
+import { isEmpty } from 'lodash-es';
 
 import { TrainingConfiguration } from '../../../../../../../core/configurable-parameters/services/configuration.interface';
 import { FineTuneParameters } from './fine-tune-parameters.component';
@@ -38,10 +39,12 @@ export const Training: FC<TrainingProps> = ({
                 isReshufflingSubsetsEnabled={isReshufflingSubsetsEnabled}
                 onReshufflingSubsetsEnabledChange={onReshufflingSubsetsEnabledChange}
             />
-            <LearningParameters
-                parameters={trainingConfiguration.training}
-                onUpdateTrainingConfiguration={onUpdateTrainingConfiguration}
-            />
+            {!isEmpty(trainingConfiguration.training) && (
+                <LearningParameters
+                    parameters={trainingConfiguration.training}
+                    onUpdateTrainingConfiguration={onUpdateTrainingConfiguration}
+                />
+            )}
         </View>
     );
 };


### PR DESCRIPTION
## 📝 Description

* Hide learning params if training learning configuration is empty

<img width="1243" height="1102" alt="Screenshot 2025-07-28 at 11 39 58" src="https://github.com/user-attachments/assets/92ae629a-8ced-4506-8a6b-33260bf01032" />
<img width="1277" height="1152" alt="Screenshot 2025-07-28 at 11 39 43" src="https://github.com/user-attachments/assets/614f5746-1236-41cb-89db-77f16cb3a7e4" />



## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
