### PR TITLE
Only show specific tiling parameters when mode is custom

### DIFF
--- a/web_ui/src/pages/project-details/components/project-model/model-configurable-parameters/trained-model-configuration-parameters/model-data-management-parameters.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-model/model-configurable-parameters/trained-model-configuration-parameters/model-data-management-parameters.component.tsx
@@ -7,7 +7,10 @@ import { isEmpty, noop } from 'lodash-es';
 import { TrainedModelConfiguration } from '../../../../../../core/configurable-parameters/services/configuration.interface';
 import { DataAugmentationParametersList } from '../../../project-models/train-model-dialog/advanced-settings/data-management/data-augmentation/data-augmentation-parameters-list.component';
 import { isDataAugmentationEnabled } from '../../../project-models/train-model-dialog/advanced-settings/data-management/data-augmentation/data-augmentation.component';
-import { TilingModeTooltip } from '../../../project-models/train-model-dialog/advanced-settings/data-management/tiling/tiling-modes.component';
+import {
+    TILING_MODES,
+    TilingModeTooltip,
+} from '../../../project-models/train-model-dialog/advanced-settings/data-management/tiling/tiling-modes.component';
 import {
     getCustomTilingParameters,
     getTilingMode,
@@ -60,7 +63,9 @@ const TilingParameters = ({ parameters }: TilingParametersProps) => {
             <Accordion.Content>
                 <Flex direction={'column'} gap={'size-300'}>
                     <TilingMode tilingMode={tilingMode} />
-                    <Parameters parameters={customTilingParameters} onChange={noop} isReadOnly />
+                    {tilingMode === TILING_MODES.CUSTOM && (
+                        <Parameters parameters={customTilingParameters} onChange={noop} isReadOnly />
+                    )}
                 </Flex>
             </Accordion.Content>
         </Accordion>

--- a/web_ui/src/pages/project-details/components/project-model/model-configurable-parameters/trained-model-configuration-parameters/trained-model-configuration-parameters.test.tsx
+++ b/web_ui/src/pages/project-details/components/project-model/model-configurable-parameters/trained-model-configuration-parameters/trained-model-configuration-parameters.test.tsx
@@ -127,7 +127,7 @@ describe('TrainedModelConfigurationParameters', () => {
                 key: 'adaptive_tiling',
                 type: 'bool',
                 name: 'Adaptive tiling',
-                value: true,
+                value: false,
                 description: 'Whether to use adaptive tiling based on image content',
                 defaultValue: false,
             }),
@@ -165,7 +165,7 @@ describe('TrainedModelConfigurationParameters', () => {
 
         expect(screen.getByRole('tab', { name: 'Data management' })).toBeInTheDocument();
 
-        expect(screen.getByLabelText('Tiling mode')).toHaveTextContent('Automatic');
+        expect(screen.getByLabelText('Tiling mode')).toHaveTextContent('Custom');
 
         tilingParameters.slice(2).forEach((parameter) => {
             expectParameterToHaveValue(parameter.name, parameter.value);
@@ -182,5 +182,64 @@ describe('TrainedModelConfigurationParameters', () => {
         render(<TrainedModelConfigurationParametersList parameters={parameters} />);
 
         expect(screen.queryByRole('tab', { name: 'Data management' })).not.toBeInTheDocument();
+    });
+
+    it('does not display custom tiling parameters when tiling is not custom', () => {
+        const tilingParameters = [
+            getMockedConfigurationParameter({
+                key: 'enable',
+                type: 'bool',
+                name: 'Enable tiling',
+                value: true,
+                description: 'Whether to apply tiling to the image',
+                defaultValue: false,
+            }),
+            getMockedConfigurationParameter({
+                key: 'adaptive_tiling',
+                type: 'bool',
+                name: 'Adaptive tiling',
+                value: true,
+                description: 'Whether to use adaptive tiling based on image content',
+                defaultValue: false,
+            }),
+            getMockedConfigurationParameter({
+                key: 'tile_size',
+                type: 'int',
+                name: 'Tile size',
+                value: 256,
+                description: 'Size of each tile in pixels',
+                defaultValue: 128,
+                maxValue: null,
+                minValue: 0,
+            }),
+            getMockedConfigurationParameter({
+                key: 'tile_overlap',
+                type: 'int',
+                name: 'Tile overlap',
+                value: 64,
+                description: 'Overlap between adjacent tiles in pixels',
+                defaultValue: 64,
+                maxValue: null,
+                minValue: 0,
+            }),
+        ];
+
+        const parameters = getMockedTrainedModelConfigurationParameters({
+            datasetPreparation: {
+                augmentation: {
+                    tiling: tilingParameters,
+                },
+            },
+        });
+
+        render(<TrainedModelConfigurationParametersList parameters={parameters} />);
+
+        expect(screen.queryByRole('tab', { name: 'Data management' })).toBeInTheDocument();
+
+        expect(screen.getByLabelText('Tiling mode')).toHaveTextContent('Automatic');
+
+        tilingParameters.slice(2).forEach((parameter) => {
+            expect(screen.queryByLabelText(parameter.name)).not.toBeInTheDocument();
+        });
     });
 });


### PR DESCRIPTION
## 📝 Description

Currently the backend always returns the custom tiling parameters even when they are not being used.
We need this as these values are used to determine the default paramter values when configuring a new model. So atm we can't remove these parameters from the API when tiling mode is off.

<img width="764" height="194" alt="image" src="https://github.com/user-attachments/assets/9d1c8932-e81f-4ab2-bace-07493f9ba8ae" />

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [x] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
