### PR TITLE
Add extra spaces to models name in project tests page for readability

### DIFF
--- a/web_ui/src/pages/project-details/components/project-test/project-test.module.scss
+++ b/web_ui/src/pages/project-details/components/project-test/project-test.module.scss
@@ -53,3 +53,7 @@
 .mediaBucketAbove {
     border: 1px solid var(--brand-moss);
 }
+
+.detailedModelName {
+    word-spacing: var(--spectrum-global-dimension-size-100);
+}

--- a/web_ui/src/pages/project-details/components/project-test/project-test.module.scss
+++ b/web_ui/src/pages/project-details/components/project-test/project-test.module.scss
@@ -5,6 +5,7 @@
 
 .testDetailsCardItem {
     font-size: var(--spectrum-global-dimension-font-size-200) !important;
+    word-spacing: normal !important;
 }
 
 .mediaItemsBucket {

--- a/web_ui/src/pages/project-details/components/project-test/test-details-card.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-test/test-details-card.component.tsx
@@ -13,7 +13,8 @@ import { formatTestDate, formatTestTime } from '../project-tests/utils';
 import classes from './project-test.module.scss';
 
 interface TestDetailsCardProps {
-    modelName: string;
+    modeTemplateName: string;
+    groupName: string;
     version: number;
     testingSetName: string;
     creationDate: string;
@@ -24,7 +25,8 @@ interface TestDetailsCardProps {
 }
 
 export const TestDetailsCard = ({
-    modelName,
+    modeTemplateName,
+    groupName,
     version,
     testingSetName,
     creationDate,
@@ -42,8 +44,11 @@ export const TestDetailsCard = ({
                         <DomainName domain={taskName} />
                     </TestDetailCardBoldItem>
                     <Text>Model:</Text>
-                    <Text>
-                        <TestDetailCardBoldItem id={'test-details-model-name-id'}>{modelName} </TestDetailCardBoldItem>
+                    <Text UNSAFE_className={classes.extraSpaceInModelName}>
+                        <TestDetailCardBoldItem id={'test-details-model-name-id'}>
+                            {modeTemplateName}
+                        </TestDetailCardBoldItem>{' '}
+                        <TestDetailCardBoldItem id={'test-details-model-name-id'}>({groupName})</TestDetailCardBoldItem>{' '}
                         <TestDetailCardItem id={'test-details-model-version-id'}>Version {version}</TestDetailCardItem>
                     </Text>
                     <Text>Testing set:</Text>

--- a/web_ui/src/pages/project-details/components/project-test/test-details-card.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-test/test-details-card.component.tsx
@@ -13,7 +13,7 @@ import { formatTestDate, formatTestTime } from '../project-tests/utils';
 import classes from './project-test.module.scss';
 
 interface TestDetailsCardProps {
-    modeTemplateName: string;
+    modelTemplateName: string;
     groupName: string;
     version: number;
     testingSetName: string;
@@ -25,7 +25,7 @@ interface TestDetailsCardProps {
 }
 
 export const TestDetailsCard = ({
-    modeTemplateName,
+    modelTemplateName,
     groupName,
     version,
     testingSetName,
@@ -44,11 +44,13 @@ export const TestDetailsCard = ({
                         <DomainName domain={taskName} />
                     </TestDetailCardBoldItem>
                     <Text>Model:</Text>
-                    <Text UNSAFE_className={classes.extraSpaceInModelName}>
+                    <Text UNSAFE_className={classes.detailedModelName}>
                         <TestDetailCardBoldItem id={'test-details-model-name-id'}>
-                            {modeTemplateName}
+                            {modelTemplateName}
                         </TestDetailCardBoldItem>{' '}
-                        <TestDetailCardBoldItem id={'test-details-model-name-id'}>({groupName})</TestDetailCardBoldItem>{' '}
+                        <TestDetailCardBoldItem id={'test-details-model-group-id'}>
+                            ({groupName})
+                        </TestDetailCardBoldItem>{' '}
                         <TestDetailCardItem id={'test-details-model-version-id'}>Version {version}</TestDetailCardItem>
                     </Text>
                     <Text>Testing set:</Text>

--- a/web_ui/src/pages/project-details/components/project-test/test-details.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-test/test-details.component.tsx
@@ -72,7 +72,8 @@ export const TestDetails = ({ test }: TestDetailsProps): JSX.Element => {
             <TestDetailsCard
                 version={version}
                 creationDate={creationTime}
-                modelName={`${modelTemplateName} (${groupName})`}
+                modeTemplateName={modelTemplateName}
+                groupName={groupName}
                 testingSetName={datasetName}
                 numberOfLabels={numberOfLabels}
                 numberOfImages={numberOfImages}

--- a/web_ui/src/pages/project-details/components/project-test/test-details.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-test/test-details.component.tsx
@@ -72,7 +72,7 @@ export const TestDetails = ({ test }: TestDetailsProps): JSX.Element => {
             <TestDetailsCard
                 version={version}
                 creationDate={creationTime}
-                modeTemplateName={modelTemplateName}
+                modelTemplateName={modelTemplateName}
                 groupName={groupName}
                 testingSetName={datasetName}
                 numberOfLabels={numberOfLabels}


### PR DESCRIPTION
## 📝 Description

For readability purposes some extra spacing was added to Models Name in test details page
before:
<img width="505" height="233" alt="Screenshot 2025-07-29 at 08 10 10" src="https://github.com/user-attachments/assets/fa73e4de-e538-4ff5-a817-8a4aad3f5f2e" />

after:
<img width="505" height="233" alt="Screenshot 2025-07-29 at 08 10 22" src="https://github.com/user-attachments/assets/19558c97-4681-4935-8cce-b52fc3997be4" />


## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [x] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
