### PR TITLE
Bugfix: cannot export non-openvino model when querying with model_only=false

### DIFF
--- a/interactive_ai/services/resource/app/communication/rest_controllers/model_controller.py
+++ b/interactive_ai/services/resource/app/communication/rest_controllers/model_controller.py
@@ -384,7 +384,7 @@ class ModelRESTController:
                         _filename = "model.bin"
                 info = ZipInfo(_filename)
                 zf.writestr(info, adapter.data)
-            if not model_only:
+            if not model_only and model.model_format is ModelFormat.OPENVINO:
                 config = DeploymentPackageManager.extract_config_json_from_xml(
                     model.model_adapters[OVWeightsKey.OPENVINO_XML.value].data
                 )

--- a/interactive_ai/services/resource/tests/unit/communication/rest_controllers/test_model_controller.py
+++ b/interactive_ai/services/resource/tests/unit/communication/rest_controllers/test_model_controller.py
@@ -63,14 +63,10 @@ class TestModelRESTController:
         project_id = fxt_project.id_
         model_storage_id = fxt_model.model_storage.id_
         model_id = fxt_model.id_
-        config_json = {"dummy_key": "dummy_value"}
 
         with (
             patch.object(ProjectRepo, "get_by_id", return_value=fxt_project) as mock_get_project,
             patch.object(ModelRepo, "get_by_id", return_value=fxt_model) as mock_get_model,
-            patch.object(
-                DeploymentPackageManager, "extract_config_json_from_xml", return_value=config_json
-            ) as mock_extract_config_json,
         ):
             result_file, result_file_name = ModelRESTController.export_model(
                 project_id=project_id,
@@ -82,10 +78,7 @@ class TestModelRESTController:
             mock_get_project.assert_called_once()
             mock_get_model.assert_called_once()
             compare(result_file_name, "ONNX_model.zip", ignore_eq=True)
-            if model_only:
-                compare(result_file.read(), fxt_zip_file_data.read(), ignore_eq=True)
-            else:
-                mock_extract_config_json.assert_called_once()
+            compare(result_file.read(), fxt_zip_file_data.read(), ignore_eq=True)
 
     @pytest.mark.parametrize("model_only", [True, False])
     def test_export_optimized_model(


### PR DESCRIPTION
## 📝 Description

- Error code 500 is returned by resource service when it is requested to export a ONNX model with query `model_only=false`. 
- `config.json` should only be returned for openvino models

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [x] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
