### PR TITLE
Added  an option to select models for archive during project export process

### DIFF
--- a/web_ui/packages/core/src/services/urls.ts
+++ b/web_ui/packages/core/src/services/urls.ts
@@ -132,10 +132,10 @@ const PROJECT_NAMES = (workspaceIdentifier: WorkspaceIdentifier) => `${WORKSPACE
 
 const EXPORT_PROJECT = (
     projectIdentifier: ProjectIdentifier,
-    selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS
+    selectedModelExportOption?: EXPORT_PROJECT_MODELS_OPTIONS
 ): string => {
     const baseUrl = `${PROJECT(projectIdentifier)}:export`;
-    return selectedModels ? `${baseUrl}?include_models=${selectedModels}` : baseUrl;
+    return selectedModelExportOption ? `${baseUrl}?include_models=${selectedModelExportOption}` : baseUrl;
 };
 
 // TODO Remove

--- a/web_ui/packages/core/src/services/urls.ts
+++ b/web_ui/packages/core/src/services/urls.ts
@@ -21,6 +21,7 @@ import { ModelGroupIdentifier, ModelIdentifier } from '../../../../src/core/mode
 import { OrganizationIdentifier } from '../../../../src/core/organizations/organizations.interface';
 import { ProjectIdentifier } from '../../../../src/core/projects/core.interface';
 import { DatasetIdentifier } from '../../../../src/core/projects/dataset.interface';
+import { EXPORT_PROJECT_MODELS_OPTIONS } from '../../../../src/core/projects/project.interface';
 import { ProjectsQueryOptions } from '../../../../src/core/projects/services/project-service.interface';
 import { SortDirection } from '../../../../src/core/shared/query-parameters';
 import { TaskIdentifier } from '../../../../src/core/statistics/dtos/dataset-statistics.interface';
@@ -129,7 +130,13 @@ const PROJECT = (projectIdentifier: ProjectIdentifier): string =>
 
 const PROJECT_NAMES = (workspaceIdentifier: WorkspaceIdentifier) => `${WORKSPACE(workspaceIdentifier)}/projects_names`;
 
-const EXPORT_PROJECT = (projectIdentifier: ProjectIdentifier): string => `${PROJECT(projectIdentifier)}:export`;
+const EXPORT_PROJECT = (
+    projectIdentifier: ProjectIdentifier,
+    selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS
+): string => {
+    const baseUrl = `${PROJECT(projectIdentifier)}:export`;
+    return selectedModels ? `${baseUrl}?include_models=${selectedModels}` : baseUrl;
+};
 
 // TODO Remove
 const EXPORT_PROJECT_STATUS = (projectIdentifier: ProjectIdentifier, exportProjectId: string): string =>

--- a/web_ui/src/core/projects/hooks/use-export-project.hook.test.tsx
+++ b/web_ui/src/core/projects/hooks/use-export-project.hook.test.tsx
@@ -33,7 +33,7 @@ const projectService = createInMemoryProjectService();
 describe('useExportProject', () => {
     const mockData = {
         projectIdentifier: getMockedProjectExportIdentifier({ workspaceId: '1', projectId: '4', exportProjectId: '2' }),
-        selectedModels: EXPORT_PROJECT_MODELS_OPTIONS.ALL,
+        selectedModelExportOption: EXPORT_PROJECT_MODELS_OPTIONS.ALL,
     };
 
     beforeEach(() => {

--- a/web_ui/src/core/projects/hooks/use-export-project.hook.test.tsx
+++ b/web_ui/src/core/projects/hooks/use-export-project.hook.test.tsx
@@ -9,7 +9,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 
 import { NOTIFICATION_TYPE } from '../../../notification/notification-toast/notification-type.enum';
 import { getMockedProjectExportIdentifier } from '../../../test-utils/mocked-items-factory/mocked-identifiers';
-import { ProjectExport } from '../project.interface';
+import { EXPORT_PROJECT_MODELS_OPTIONS, ProjectExport } from '../project.interface';
 import { createInMemoryProjectService } from '../services/in-memory-project-service';
 import { ProjectService } from '../services/project-service.interface';
 import { useExportProject } from './use-export-project.hook';
@@ -31,7 +31,10 @@ const wrapper = ({ children, projectService }: { children?: ReactNode; projectSe
 
 const projectService = createInMemoryProjectService();
 describe('useExportProject', () => {
-    const mockData = getMockedProjectExportIdentifier({ workspaceId: '1', projectId: '4', exportProjectId: '2' });
+    const mockData = {
+        projectIdentifier: getMockedProjectExportIdentifier({ workspaceId: '1', projectId: '4', exportProjectId: '2' }),
+        selectedModels: EXPORT_PROJECT_MODELS_OPTIONS.ALL,
+    };
 
     beforeEach(() => {
         jest.clearAllMocks();

--- a/web_ui/src/core/projects/hooks/use-export-project.hook.ts
+++ b/web_ui/src/core/projects/hooks/use-export-project.hook.ts
@@ -9,10 +9,15 @@ import { getErrorMessage } from '../../../../packages/core/src/services/utils';
 import { NOTIFICATION_TYPE } from '../../../notification/notification-toast/notification-type.enum';
 import { useNotification } from '../../../notification/notification.component';
 import { ProjectIdentifier } from '../core.interface';
-import { ProjectExport } from '../project.interface';
+import { EXPORT_PROJECT_MODELS_OPTIONS, ProjectExport } from '../project.interface';
 
 interface UseExportProject {
-    exportProjectMutation: UseMutationResult<ProjectExport, AxiosError, ProjectIdentifier>;
+    exportProjectMutation: UseMutationResult<ProjectExport, AxiosError, ExportProjectMutationVariables>;
+}
+
+interface ExportProjectMutationVariables {
+    projectIdentifier: ProjectIdentifier;
+    selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS;
 }
 
 export const DOWNLOAD_STATUS_ERROR = 'Project was not downloaded due to an error.';
@@ -21,7 +26,7 @@ export const useExportProject = (): UseExportProject => {
     const { addNotification } = useNotification();
     const service = useApplicationServices().projectService;
 
-    const exportProjectMutation = useMutation<ProjectExport, AxiosError, ProjectIdentifier>({
+    const exportProjectMutation = useMutation<ProjectExport, AxiosError, ExportProjectMutationVariables>({
         mutationFn: service.exportProject,
         onError: (error: AxiosError) => {
             addNotification({ message: getErrorMessage(error), type: NOTIFICATION_TYPE.ERROR });

--- a/web_ui/src/core/projects/hooks/use-export-project.hook.ts
+++ b/web_ui/src/core/projects/hooks/use-export-project.hook.ts
@@ -17,7 +17,7 @@ interface UseExportProject {
 
 interface ExportProjectMutationVariables {
     projectIdentifier: ProjectIdentifier;
-    selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS;
+    selectedModelExportOption?: EXPORT_PROJECT_MODELS_OPTIONS;
 }
 
 export const DOWNLOAD_STATUS_ERROR = 'Project was not downloaded due to an error.';

--- a/web_ui/src/core/projects/project.interface.ts
+++ b/web_ui/src/core/projects/project.interface.ts
@@ -115,6 +115,6 @@ export interface ProjectImportStatus {
 
 export enum EXPORT_PROJECT_MODELS_OPTIONS {
     ALL = 'all',
-    NONE = 'none',
     LATEST_ACTIVE = 'latest_active',
+    NONE = 'none',
 }

--- a/web_ui/src/core/projects/project.interface.ts
+++ b/web_ui/src/core/projects/project.interface.ts
@@ -112,3 +112,9 @@ export interface ProjectImportStatus {
     state: ExportStatusStateDTO;
     message?: string | null;
 }
+
+export enum EXPORT_PROJECT_MODELS_OPTIONS {
+    ALL = 'all',
+    NONE = 'none',
+    LATEST_ACTIVE = 'latest_active',
+}

--- a/web_ui/src/core/projects/services/api-project-service.ts
+++ b/web_ui/src/core/projects/services/api-project-service.ts
@@ -162,10 +162,13 @@ export const createApiProjectService: CreateApiService<ProjectService> = (
         };
     };
 
-    const exportProject = async (
-        projectIdentifier: ProjectIdentifier,
-        selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS
-    ): Promise<ProjectExport> => {
+    const exportProject = async ({
+        projectIdentifier,
+        selectedModels,
+    }: {
+        projectIdentifier: ProjectIdentifier;
+        selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS;
+    }): Promise<ProjectExport> => {
         const { data } = await instance.post<ProjectExportDTO>(
             router.EXPORT_PROJECT(projectIdentifier, selectedModels)
         );

--- a/web_ui/src/core/projects/services/api-project-service.ts
+++ b/web_ui/src/core/projects/services/api-project-service.ts
@@ -37,6 +37,7 @@ import { ProjectExportDTO, ProjectImportDTO } from '../dtos/task.interface';
 import { ProjectStatus } from '../project-status.interface';
 import {
     CreateProjectProps,
+    EXPORT_PROJECT_MODELS_OPTIONS,
     ProjectExport,
     ProjectExportIdentifier,
     ProjectImport,
@@ -161,8 +162,13 @@ export const createApiProjectService: CreateApiService<ProjectService> = (
         };
     };
 
-    const exportProject = async (projectIdentifier: ProjectIdentifier): Promise<ProjectExport> => {
-        const { data } = await instance.post<ProjectExportDTO>(router.EXPORT_PROJECT(projectIdentifier));
+    const exportProject = async (
+        projectIdentifier: ProjectIdentifier,
+        selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS
+    ): Promise<ProjectExport> => {
+        const { data } = await instance.post<ProjectExportDTO>(
+            router.EXPORT_PROJECT(projectIdentifier, selectedModels)
+        );
 
         return {
             exportProjectId: data.job_id,

--- a/web_ui/src/core/projects/services/api-project-service.ts
+++ b/web_ui/src/core/projects/services/api-project-service.ts
@@ -164,13 +164,13 @@ export const createApiProjectService: CreateApiService<ProjectService> = (
 
     const exportProject = async ({
         projectIdentifier,
-        selectedModels,
+        selectedModelExportOption,
     }: {
         projectIdentifier: ProjectIdentifier;
-        selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS;
+        selectedModelExportOption?: EXPORT_PROJECT_MODELS_OPTIONS;
     }): Promise<ProjectExport> => {
         const { data } = await instance.post<ProjectExportDTO>(
-            router.EXPORT_PROJECT(projectIdentifier, selectedModels)
+            router.EXPORT_PROJECT(projectIdentifier, selectedModelExportOption)
         );
 
         return {

--- a/web_ui/src/core/projects/services/in-memory-project-service.ts
+++ b/web_ui/src/core/projects/services/in-memory-project-service.ts
@@ -380,10 +380,10 @@ export const createInMemoryProjectService = (): ProjectService => {
 
     const exportProject = async ({
         projectIdentifier,
-        selectedModels,
+        selectedModelExportOption,
     }: {
         projectIdentifier: ProjectIdentifier;
-        selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS;
+        selectedModelExportOption?: EXPORT_PROJECT_MODELS_OPTIONS;
     }): Promise<ProjectExport> => {
         return {
             exportProjectId: '62ea1a69f00a19754326589c',

--- a/web_ui/src/core/projects/services/in-memory-project-service.ts
+++ b/web_ui/src/core/projects/services/in-memory-project-service.ts
@@ -35,8 +35,6 @@ import {
 import { PerformanceType, TaskMetadata } from '../task.interface';
 import { ImportOptions, ProjectService } from './project-service.interface';
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 const inMemoryDatasets = [
     {
         id: 'in-memory-dataset',
@@ -378,10 +376,7 @@ export const createInMemoryProjectService = (): ProjectService => {
         };
     };
 
-    const exportProject = async ({
-        projectIdentifier,
-        selectedModelExportOption,
-    }: {
+    const exportProject = async (_: {
         projectIdentifier: ProjectIdentifier;
         selectedModelExportOption?: EXPORT_PROJECT_MODELS_OPTIONS;
     }): Promise<ProjectExport> => {

--- a/web_ui/src/core/projects/services/in-memory-project-service.ts
+++ b/web_ui/src/core/projects/services/in-memory-project-service.ts
@@ -23,6 +23,7 @@ import {
 import { ProjectStatus } from '../project-status.interface';
 import {
     CreateProjectProps,
+    EXPORT_PROJECT_MODELS_OPTIONS,
     ProjectExport,
     ProjectExportIdentifier,
     ProjectImport,
@@ -33,6 +34,8 @@ import {
 } from '../project.interface';
 import { PerformanceType, TaskMetadata } from '../task.interface';
 import { ImportOptions, ProjectService } from './project-service.interface';
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
 
 const inMemoryDatasets = [
     {
@@ -375,7 +378,13 @@ export const createInMemoryProjectService = (): ProjectService => {
         };
     };
 
-    const exportProject = async (_datasetIdentifier: DatasetIdentifier): Promise<ProjectExport> => {
+    const exportProject = async ({
+        projectIdentifier,
+        selectedModels,
+    }: {
+        projectIdentifier: ProjectIdentifier;
+        selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS;
+    }): Promise<ProjectExport> => {
         return {
             exportProjectId: '62ea1a69f00a19754326589c',
         };

--- a/web_ui/src/core/projects/services/project-service.interface.ts
+++ b/web_ui/src/core/projects/services/project-service.interface.ts
@@ -19,6 +19,7 @@ import { ProjectStatus } from '../project-status.interface';
 import {
     CreateProjectProps,
     EditProjectProps,
+    EXPORT_PROJECT_MODELS_OPTIONS,
     ProjectExport,
     ProjectExportIdentifier,
     ProjectImport,
@@ -68,7 +69,13 @@ export interface ProjectService {
         domains: DOMAIN[],
         projectTypeMetadata: TaskMetadata[]
     ): Promise<CreateProjectProps>;
-    exportProject(projectIdentifier: ProjectIdentifier): Promise<ProjectExport>;
+    exportProject({
+        projectIdentifier,
+        selectedModels,
+    }: {
+        projectIdentifier: ProjectIdentifier;
+        selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS;
+    }): Promise<ProjectExport>;
     exportProjectStatus(projectIdentifier: ProjectExportIdentifier): Promise<JobProjectExportStatus>;
     importProject(projectImportFileIdentifier: ProjectImportIdentifier, options: ImportOptions): Promise<ProjectImport>;
     getImportProjectStatus(projectImportIdentifier: ProjectImportIdentifier): Promise<ProjectImportStatus>;

--- a/web_ui/src/core/projects/services/project-service.interface.ts
+++ b/web_ui/src/core/projects/services/project-service.interface.ts
@@ -71,10 +71,10 @@ export interface ProjectService {
     ): Promise<CreateProjectProps>;
     exportProject({
         projectIdentifier,
-        selectedModels,
+        selectedModelExportOption,
     }: {
         projectIdentifier: ProjectIdentifier;
-        selectedModels?: EXPORT_PROJECT_MODELS_OPTIONS;
+        selectedModelExportOption?: EXPORT_PROJECT_MODELS_OPTIONS;
     }): Promise<ProjectExport>;
     exportProjectStatus(projectIdentifier: ProjectExportIdentifier): Promise<JobProjectExportStatus>;
     importProject(projectImportFileIdentifier: ProjectImportIdentifier, options: ImportOptions): Promise<ProjectImport>;

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
@@ -78,7 +78,7 @@ export const ExportProjectDialog = ({
                                 <Button variant='secondary' onPress={handleDismiss}>
                                     Cancel
                                 </Button>
-                                <Button type='submit' variant='accent' isDisabled={isSaveButtonDisabled}>
+                                <Button type='submit' variant='accent'>
                                     Export
                                 </Button>
                             </ButtonGroup>

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
@@ -27,7 +27,7 @@ interface ExportProjectDialogProps {
 }
 
 export const ExportProjectDialog = ({ onClose, isOpen, onExportProject }: ExportProjectDialogProps): JSX.Element => {
-    const [selectedModels, setSelectedModels] = useState('');
+    const [selectedModels, setSelectedModels] = useState(EXPORT_PROJECT_MODELS_OPTIONS.ALL);
     const isSaveButtonDisabled = isEmpty(selectedModels);
 
     const handleExportProject = async (event: FormEvent<HTMLFormElement>) => {

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
@@ -10,6 +10,7 @@ import {
     Dialog,
     DialogContainer,
     Divider,
+    Flex,
     Form,
     Heading,
     Radio,
@@ -19,6 +20,7 @@ import {
 import { ProjectIdentifier } from '../../../../../../../../../core/projects/core.interface';
 import { EXPORT_PROJECT_MODELS_OPTIONS } from '../../../../../../../../../core/projects/project.interface';
 import { useWorkspaceIdentifier } from '../../../../../../../../../providers/workspaces-provider/use-workspace-identifier.hook';
+import { InfoTooltip } from '../../../../../../../../../shared/components/info-tooltip/info-tooltip.component';
 import { formatToLabel } from './utils';
 
 interface ExportProjectDialogProps {
@@ -56,7 +58,16 @@ export const ExportProjectDialog = ({
                     <Content>
                         <Form onSubmit={handleExportProject}>
                             <RadioGroup
-                                label={'Select models for export'}
+                                label={
+                                    <Flex gap={'size-50'} alignItems={'center'}>
+                                        <span>Select models for export</span>
+                                        <InfoTooltip
+                                            tooltipText={
+                                                'Each model will be exported along with all of its optimized variants.'
+                                            }
+                                        />
+                                    </Flex>
+                                }
                                 aria-label={'Export models'}
                                 value={selectedModelExportOption}
                                 onChange={(option: string) =>

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
@@ -17,18 +17,27 @@ import {
 } from '@geti/ui';
 import { isEmpty } from 'lodash-es';
 
+import { ProjectIdentifier } from '../../../../../../../../../core/projects/core.interface';
 import { EXPORT_PROJECT_MODELS_OPTIONS } from '../../../../../../../../../core/projects/project.interface';
+import { useWorkspaceIdentifier } from '../../../../../../../../../providers/workspaces-provider/use-workspace-identifier.hook';
 import { formatToLabel } from './utils';
 
 interface ExportProjectDialogProps {
     isOpen: boolean;
+    projectId: string;
     onClose: () => void;
-    onExportProject: () => void;
+    onExportProject: (projectIdentifier: ProjectIdentifier, selectedModels: EXPORT_PROJECT_MODELS_OPTIONS) => void;
 }
 
-export const ExportProjectDialog = ({ onClose, isOpen, onExportProject }: ExportProjectDialogProps): JSX.Element => {
+export const ExportProjectDialog = ({
+    onClose,
+    isOpen,
+    onExportProject,
+    projectId,
+}: ExportProjectDialogProps): JSX.Element => {
     const [selectedModels, setSelectedModels] = useState(EXPORT_PROJECT_MODELS_OPTIONS.ALL);
     const isSaveButtonDisabled = isEmpty(selectedModels);
+    const { organizationId, workspaceId } = useWorkspaceIdentifier();
 
     const handleExportProject = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -37,7 +46,7 @@ export const ExportProjectDialog = ({ onClose, isOpen, onExportProject }: Export
             return;
         }
 
-        onExportProject();
+        onExportProject({ organizationId, workspaceId, projectId }, selectedModels);
         onClose();
     };
 

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
@@ -25,7 +25,10 @@ interface ExportProjectDialogProps {
     isOpen: boolean;
     projectId: string;
     onClose: () => void;
-    onExportProject: (projectIdentifier: ProjectIdentifier, selectedModels: EXPORT_PROJECT_MODELS_OPTIONS) => void;
+    onExportProject: (
+        projectIdentifier: ProjectIdentifier,
+        selectedModelExportOption: EXPORT_PROJECT_MODELS_OPTIONS
+    ) => void;
 }
 
 export const ExportProjectDialog = ({
@@ -34,13 +37,13 @@ export const ExportProjectDialog = ({
     onExportProject,
     projectId,
 }: ExportProjectDialogProps): JSX.Element => {
-    const [selectedModels, setSelectedModels] = useState(EXPORT_PROJECT_MODELS_OPTIONS.ALL);
+    const [selectedModelExportOption, setSelectedModelExportOption] = useState(EXPORT_PROJECT_MODELS_OPTIONS.ALL);
     const { organizationId, workspaceId } = useWorkspaceIdentifier();
 
     const handleExportProject = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
 
-        onExportProject({ organizationId, workspaceId, projectId }, selectedModels);
+        onExportProject({ organizationId, workspaceId, projectId }, selectedModelExportOption);
         onClose();
     };
 
@@ -59,9 +62,9 @@ export const ExportProjectDialog = ({
                             <RadioGroup
                                 label={'Select models for export'}
                                 aria-label={'Export models'}
-                                value={selectedModels}
+                                value={selectedModelExportOption}
                                 onChange={(option: string) =>
-                                    setSelectedModels(option as EXPORT_PROJECT_MODELS_OPTIONS)
+                                    setSelectedModelExportOption(option as EXPORT_PROJECT_MODELS_OPTIONS)
                                 }
                             >
                                 {Object.values(EXPORT_PROJECT_MODELS_OPTIONS).map(

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
@@ -1,0 +1,83 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+import { FormEvent, useState } from 'react';
+
+import {
+    Button,
+    ButtonGroup,
+    Content,
+    Dialog,
+    DialogContainer,
+    Divider,
+    Form,
+    Heading,
+    Radio,
+    RadioGroup,
+} from '@geti/ui';
+import { isEmpty } from 'lodash-es';
+
+import { AVAILABLE_EXPORT_MODELS, formatToLabel } from './utils';
+
+interface ExportProjectDialogProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onExportProject: () => void;
+}
+
+export const ExportProjectDialog = ({ onClose, isOpen, onExportProject }: ExportProjectDialogProps): JSX.Element => {
+    const [selectedModels, setSelectedModels] = useState('');
+    const isSaveButtonDisabled = isEmpty(selectedModels);
+
+    const handleExportProject = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (isSaveButtonDisabled) {
+            return;
+        }
+
+        onExportProject();
+        onClose();
+    };
+
+    const handleDismiss = () => {
+        onClose();
+    };
+
+    return (
+        <DialogContainer onDismiss={handleDismiss}>
+            {isOpen && (
+                <Dialog>
+                    <Heading>Export project</Heading>
+                    <Divider />
+                    <Content>
+                        <Form onSubmit={handleExportProject}>
+                            <RadioGroup
+                                label={'Select models for export'}
+                                aria-label={'Export models'}
+                                value={selectedModels}
+                                onChange={(option: string) => setSelectedModels(option as AVAILABLE_EXPORT_MODELS)}
+                            >
+                                {Object.values(AVAILABLE_EXPORT_MODELS).map((model: AVAILABLE_EXPORT_MODELS) => {
+                                    return (
+                                        <Radio value={model} aria-label={model}>
+                                            {formatToLabel(model)}
+                                        </Radio>
+                                    );
+                                })}
+                            </RadioGroup>
+                            <ButtonGroup align={'end'} marginTop={'size-350'}>
+                                <Button variant='secondary' onPress={handleDismiss}>
+                                    Cancel
+                                </Button>
+                                <Button type='submit' variant='accent' isDisabled={isSaveButtonDisabled}>
+                                    Export
+                                </Button>
+                            </ButtonGroup>
+                        </Form>
+                    </Content>
+                </Dialog>
+            )}
+        </DialogContainer>
+    );
+};

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
@@ -47,12 +47,8 @@ export const ExportProjectDialog = ({
         onClose();
     };
 
-    const handleDismiss = () => {
-        onClose();
-    };
-
     return (
-        <DialogContainer onDismiss={handleDismiss}>
+        <DialogContainer onDismiss={onClose}>
             {isOpen && (
                 <Dialog>
                     <Heading>Export project</Heading>
@@ -78,7 +74,7 @@ export const ExportProjectDialog = ({
                                 )}
                             </RadioGroup>
                             <ButtonGroup align={'end'} marginTop={'size-350'}>
-                                <Button variant='secondary' onPress={handleDismiss}>
+                                <Button variant='secondary' onPress={onClose}>
                                     Cancel
                                 </Button>
                                 <Button type='submit' variant='accent'>

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
@@ -17,7 +17,8 @@ import {
 } from '@geti/ui';
 import { isEmpty } from 'lodash-es';
 
-import { AVAILABLE_EXPORT_MODELS, formatToLabel } from './utils';
+import { EXPORT_PROJECT_MODELS_OPTIONS } from '../../../../../../../../../core/projects/project.interface';
+import { formatToLabel } from './utils';
 
 interface ExportProjectDialogProps {
     isOpen: boolean;
@@ -56,15 +57,19 @@ export const ExportProjectDialog = ({ onClose, isOpen, onExportProject }: Export
                                 label={'Select models for export'}
                                 aria-label={'Export models'}
                                 value={selectedModels}
-                                onChange={(option: string) => setSelectedModels(option as AVAILABLE_EXPORT_MODELS)}
+                                onChange={(option: string) =>
+                                    setSelectedModels(option as EXPORT_PROJECT_MODELS_OPTIONS)
+                                }
                             >
-                                {Object.values(AVAILABLE_EXPORT_MODELS).map((model: AVAILABLE_EXPORT_MODELS) => {
-                                    return (
-                                        <Radio value={model} aria-label={model}>
-                                            {formatToLabel(model)}
-                                        </Radio>
-                                    );
-                                })}
+                                {Object.values(EXPORT_PROJECT_MODELS_OPTIONS).map(
+                                    (model: EXPORT_PROJECT_MODELS_OPTIONS) => {
+                                        return (
+                                            <Radio key={model} value={model} aria-label={model}>
+                                                {formatToLabel(model)}
+                                            </Radio>
+                                        );
+                                    }
+                                )}
                             </RadioGroup>
                             <ButtonGroup align={'end'} marginTop={'size-350'}>
                                 <Button variant='secondary' onPress={handleDismiss}>

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.component.tsx
@@ -15,7 +15,6 @@ import {
     Radio,
     RadioGroup,
 } from '@geti/ui';
-import { isEmpty } from 'lodash-es';
 
 import { ProjectIdentifier } from '../../../../../../../../../core/projects/core.interface';
 import { EXPORT_PROJECT_MODELS_OPTIONS } from '../../../../../../../../../core/projects/project.interface';
@@ -36,15 +35,10 @@ export const ExportProjectDialog = ({
     projectId,
 }: ExportProjectDialogProps): JSX.Element => {
     const [selectedModels, setSelectedModels] = useState(EXPORT_PROJECT_MODELS_OPTIONS.ALL);
-    const isSaveButtonDisabled = isEmpty(selectedModels);
     const { organizationId, workspaceId } = useWorkspaceIdentifier();
 
     const handleExportProject = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-
-        if (isSaveButtonDisabled) {
-            return;
-        }
 
         onExportProject({ organizationId, workspaceId, projectId }, selectedModels);
         onClose();

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.test.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.test.tsx
@@ -1,3 +1,6 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
 import { fireEvent, render, screen } from '@testing-library/react';
 
 import { EXPORT_PROJECT_MODELS_OPTIONS } from '../../../../../../../../../core/projects/project.interface';

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.test.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/export-project-dialog.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { EXPORT_PROJECT_MODELS_OPTIONS } from '../../../../../../../../../core/projects/project.interface';
+import { RequiredProviders } from '../../../../../../../../../test-utils/required-providers-render';
+import { ExportProjectDialog } from './export-project-dialog.component';
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useParams: () => ({
+        organizationId: 'organization-id',
+        workspaceId: 'workspace-id',
+    }),
+}));
+
+describe('ExportProjectDialog', () => {
+    const onClose = jest.fn();
+    const onExportProject = jest.fn();
+
+    const defaultProps = {
+        isOpen: true,
+        projectId: 'project-id',
+        onClose,
+        onExportProject,
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('renders dialog with heading and radio options', () => {
+        render(
+            <RequiredProviders>
+                <ExportProjectDialog {...defaultProps} />
+            </RequiredProviders>
+        );
+        expect(screen.getByText(/Export project/i)).toBeInTheDocument();
+        expect(screen.getByLabelText(/Select models for export/i)).toBeInTheDocument();
+    });
+
+    it('calls onClose when dialog is dismissed', () => {
+        render(
+            <RequiredProviders>
+                <ExportProjectDialog {...defaultProps} />
+            </RequiredProviders>
+        );
+
+        defaultProps.onClose();
+
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onExportProject with correct arguments on submit when not changing radio buttons', () => {
+        render(
+            <RequiredProviders>
+                <ExportProjectDialog {...defaultProps} />
+            </RequiredProviders>
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /Export/ }));
+
+        expect(onExportProject).toHaveBeenCalledWith(
+            {
+                organizationId: 'organization-id',
+                workspaceId: 'workspace-id',
+                projectId: 'project-id',
+            },
+            EXPORT_PROJECT_MODELS_OPTIONS.ALL
+        );
+        expect(onClose).toHaveBeenCalled();
+    });
+
+    it('calls onExportProject with correct arguments on submit when radio button changed', () => {
+        render(
+            <RequiredProviders>
+                <ExportProjectDialog {...defaultProps} />
+            </RequiredProviders>
+        );
+
+        fireEvent.click(screen.getByText('None'));
+        fireEvent.click(screen.getByRole('button', { name: /Export/ }));
+
+        expect(onExportProject).toHaveBeenCalledWith(
+            {
+                organizationId: 'organization-id',
+                workspaceId: 'workspace-id',
+                projectId: 'project-id',
+            },
+            EXPORT_PROJECT_MODELS_OPTIONS.NONE
+        );
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/project-action-menu.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/project-action-menu.component.tsx
@@ -9,7 +9,10 @@ import { isEmpty } from 'lodash-es';
 import { useOverlayTriggerState } from 'react-stately';
 
 import { ProjectIdentifier } from '../../../../../../../../../core/projects/core.interface';
-import { ProjectProps } from '../../../../../../../../../core/projects/project.interface';
+import {
+    EXPORT_PROJECT_MODELS_OPTIONS,
+    ProjectProps,
+} from '../../../../../../../../../core/projects/project.interface';
 import { useWorkspaceIdentifier } from '../../../../../../../../../providers/workspaces-provider/use-workspace-identifier.hook';
 import { ActionMenu } from '../../../../../../../../../shared/components/action-menu/action-menu.component';
 import { MenuAction } from '../../../../../../../../../shared/components/action-menu/menu-action.interface';
@@ -22,7 +25,7 @@ import { ExportProjectDialog } from './export-project-dialog.component';
 interface ActionMenuProps {
     project: ProjectProps;
     isExporting: boolean;
-    onExportProject: (projectIdentifier: ProjectIdentifier) => void;
+    onExportProject: (projectIdentifier: ProjectIdentifier, selectedModels: EXPORT_PROJECT_MODELS_OPTIONS) => void;
     onDeleteProject: (projectIdentifier: ProjectIdentifier, onSuccess: () => void) => void;
 }
 
@@ -111,7 +114,8 @@ export const ProjectActionMenu = ({
             <ExportProjectDialog
                 onClose={exportProjectNameDialogState.close}
                 isOpen={exportProjectNameDialogState.isOpen}
-                onExportProject={() => onExportProject({ organizationId, workspaceId, projectId: project.id })}
+                onExportProject={onExportProject}
+                projectId={project.id}
             />
 
             {canEditProject && (

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/project-action-menu.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/project-action-menu.component.tsx
@@ -17,6 +17,7 @@ import { useCheckPermission } from '../../../../../../../../../shared/components
 import { OPERATION } from '../../../../../../../../../shared/components/has-permission/has-permission.interface';
 import { DeleteProjectDialog } from './delete-project-dialog.component';
 import { EditProjectNameDialog } from './edit-project-name-dialog.component';
+import { ExportProjectDialog } from './export-project-dialog.component';
 
 interface ActionMenuProps {
     project: ProjectProps;
@@ -55,6 +56,7 @@ export const ProjectActionMenu = ({
 
     const [isAlertOpen, setIsAlertOpen] = useState(false);
     const editProjectNameDialogState = useOverlayTriggerState({});
+    const exportProjectNameDialogState = useOverlayTriggerState({});
     const disabledKeys = isExporting ? [ProjectActions.Export] : [];
 
     const items: MenuAction<ProjectActions>[] = useMemo<MenuAction<ProjectActions>[]>(
@@ -79,7 +81,7 @@ export const ProjectActionMenu = ({
                 setIsAlertOpen(true);
                 break;
             case ProjectActions.Export:
-                onExportProject({ organizationId, workspaceId, projectId: project.id });
+                exportProjectNameDialogState.open();
                 break;
             case ProjectActions.Rename:
                 editProjectNameDialogState.open();
@@ -105,6 +107,12 @@ export const ProjectActionMenu = ({
                     />
                 )}
             </DialogContainer>
+
+            <ExportProjectDialog
+                onClose={exportProjectNameDialogState.close}
+                isOpen={exportProjectNameDialogState.isOpen}
+                onExportProject={() => onExportProject({ organizationId, workspaceId, projectId: project.id })}
+            />
 
             {canEditProject && (
                 <EditProjectNameDialog

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/project-action-menu.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/project-action-menu.component.tsx
@@ -25,7 +25,10 @@ import { ExportProjectDialog } from './export-project-dialog.component';
 interface ActionMenuProps {
     project: ProjectProps;
     isExporting: boolean;
-    onExportProject: (projectIdentifier: ProjectIdentifier, selectedModels: EXPORT_PROJECT_MODELS_OPTIONS) => void;
+    onExportProject: (
+        projectIdentifier: ProjectIdentifier,
+        selectedModelExportOption: EXPORT_PROJECT_MODELS_OPTIONS
+    ) => void;
     onDeleteProject: (projectIdentifier: ProjectIdentifier, onSuccess: () => void) => void;
 }
 

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/utils.ts
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/utils.ts
@@ -1,0 +1,21 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+export enum AVAILABLE_EXPORT_MODELS {
+    ALL = 'all',
+    NONE = 'none',
+    LATEST_ACTIVE = 'latest_active',
+}
+
+export const formatToLabel = (option: AVAILABLE_EXPORT_MODELS): string => {
+    switch (option) {
+        case AVAILABLE_EXPORT_MODELS.ALL:
+            return 'All models';
+        case AVAILABLE_EXPORT_MODELS.NONE:
+            return 'None';
+        case AVAILABLE_EXPORT_MODELS.LATEST_ACTIVE:
+            return 'Latest active model';
+        default:
+            return option;
+    }
+};

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/utils.ts
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/components/project-action-menu/utils.ts
@@ -1,19 +1,15 @@
 // Copyright (C) 2022-2025 Intel Corporation
 // LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 
-export enum AVAILABLE_EXPORT_MODELS {
-    ALL = 'all',
-    NONE = 'none',
-    LATEST_ACTIVE = 'latest_active',
-}
+import { EXPORT_PROJECT_MODELS_OPTIONS } from '../../../../../../../../../core/projects/project.interface';
 
-export const formatToLabel = (option: AVAILABLE_EXPORT_MODELS): string => {
+export const formatToLabel = (option: EXPORT_PROJECT_MODELS_OPTIONS): string => {
     switch (option) {
-        case AVAILABLE_EXPORT_MODELS.ALL:
+        case EXPORT_PROJECT_MODELS_OPTIONS.ALL:
             return 'All models';
-        case AVAILABLE_EXPORT_MODELS.NONE:
+        case EXPORT_PROJECT_MODELS_OPTIONS.NONE:
             return 'None';
-        case AVAILABLE_EXPORT_MODELS.LATEST_ACTIVE:
+        case EXPORT_PROJECT_MODELS_OPTIONS.LATEST_ACTIVE:
             return 'Latest active model';
         default:
             return option;

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/project.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/project.component.tsx
@@ -49,9 +49,12 @@ export const Project = ({
     const labels = getNonEmptyLabelsFromProject(tasks);
     const filteredDomains = domains.filter(isNotCropDomain);
 
-    const exportProject = (projectIdentifier: ProjectIdentifier, selectedModels: EXPORT_PROJECT_MODELS_OPTIONS) => {
+    const exportProject = (
+        projectIdentifier: ProjectIdentifier,
+        selectedModelExportOption: EXPORT_PROJECT_MODELS_OPTIONS
+    ) => {
         exportProjectMutation.mutate(
-            { projectIdentifier, selectedModels },
+            { projectIdentifier, selectedModelExportOption },
             {
                 onSuccess: () => {
                     setIsExporting(true);

--- a/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/project.component.tsx
+++ b/web_ui/src/pages/landing-page/landing-page-workspace/components/projects-list/components/project/project.component.tsx
@@ -13,7 +13,7 @@ import { getNonEmptyLabelsFromProject } from '../../../../../../../core/labels/u
 import { DOMAIN, ProjectIdentifier } from '../../../../../../../core/projects/core.interface';
 import { useExportProject } from '../../../../../../../core/projects/hooks/use-export-project.hook';
 import { useProjectActions } from '../../../../../../../core/projects/hooks/use-project-actions.hook';
-import { ProjectProps } from '../../../../../../../core/projects/project.interface';
+import { EXPORT_PROJECT_MODELS_OPTIONS, ProjectProps } from '../../../../../../../core/projects/project.interface';
 import { useWorkspaceIdentifier } from '../../../../../../../providers/workspaces-provider/use-workspace-identifier.hook';
 import { CustomWellClickable } from '../../../../../../../shared/components/custom-well/custom-well-clickable.component';
 import { DomainName } from '../../../../../../../shared/components/domain-name/domain-name.component';
@@ -49,12 +49,15 @@ export const Project = ({
     const labels = getNonEmptyLabelsFromProject(tasks);
     const filteredDomains = domains.filter(isNotCropDomain);
 
-    const exportProject = (projectIdentifier: ProjectIdentifier) => {
-        exportProjectMutation.mutate(projectIdentifier, {
-            onSuccess: () => {
-                setIsExporting(true);
-            },
-        });
+    const exportProject = (projectIdentifier: ProjectIdentifier, selectedModels: EXPORT_PROJECT_MODELS_OPTIONS) => {
+        exportProjectMutation.mutate(
+            { projectIdentifier, selectedModels },
+            {
+                onSuccess: () => {
+                    setIsExporting(true);
+                },
+            }
+        );
     };
 
     const deleteProject = (projectIdentifier: ProjectIdentifier, onSuccess: () => void) => {
@@ -166,7 +169,7 @@ export const Project = ({
                     setIsExporting={setIsExporting}
                     workspaceIdentifier={{ organizationId, workspaceId }}
                     exportProjectMutationIdentifier={{
-                        ...exportProjectMutation.variables,
+                        ...exportProjectMutation.variables?.projectIdentifier,
                         exportProjectId: exportProjectMutation.data?.exportProjectId,
                     }}
                     onResetProjectExport={exportProjectMutation.reset}

--- a/web_ui/tests/features/project-import-export/export-project.spec.ts
+++ b/web_ui/tests/features/project-import-export/export-project.spec.ts
@@ -61,8 +61,8 @@ test.describe('export project', () => {
 
         await page.goto('/');
         await page.getByLabel('action menu').click();
-
         await page.getByText(/export/i).click();
+        await page.getByRole('button', { name: 'Export' }).click();
 
         await expect(page.getByRole('button', { name: 'Download exported project' })).toBeVisible();
 
@@ -83,6 +83,7 @@ test.describe('export project', () => {
         await page.goto('/');
         await page.getByLabel('action menu').click();
         await page.getByText(/export/i).click();
+        await page.getByRole('button', { name: 'Export' }).click();
 
         await expect(page.getByText('Exporting project: Preparing project for export')).toBeVisible();
 
@@ -91,7 +92,7 @@ test.describe('export project', () => {
         await expect(page.getByText('Exporting project: Preparing project for export')).toBeHidden();
     });
 
-    test('error export', async ({ registerApiResponse, page }) => {
+    test.only('error export', async ({ registerApiResponse, page }) => {
         registerApiResponse('GetAllProjectsInAWorkspace', (_, res, ctx) => res(ctx.json(projects)));
         registerApiResponse('TriggerProjectExport', (_, res, ctx) => res(ctx.json({ job_id: exportProjectId })));
 
@@ -106,6 +107,7 @@ test.describe('export project', () => {
         await page.goto('/');
         await page.getByLabel('action menu').click();
         await page.getByText(/export/i).click();
+        await page.getByRole('button', { name: 'Export' }).click();
 
         await expect(page.getByText(/Project was not downloaded due to an error./i)).toBeVisible();
     });

--- a/web_ui/tests/features/project-import-export/export-project.spec.ts
+++ b/web_ui/tests/features/project-import-export/export-project.spec.ts
@@ -92,7 +92,7 @@ test.describe('export project', () => {
         await expect(page.getByText('Exporting project: Preparing project for export')).toBeHidden();
     });
 
-    test.only('error export', async ({ registerApiResponse, page }) => {
+    test('error export', async ({ registerApiResponse, page }) => {
         registerApiResponse('GetAllProjectsInAWorkspace', (_, res, ctx) => res(ctx.json(projects)));
         registerApiResponse('TriggerProjectExport', (_, res, ctx) => res(ctx.json({ job_id: exportProjectId })));
 


### PR DESCRIPTION
## 📝 Description

Added a dialog for project export to have an option to select which models should be included in the archive. Options are "all", "none" and "latest_active" with "all" being the default one.

<img width="557" height="315" alt="Screenshot 2025-07-31 at 16 07 29" src="https://github.com/user-attachments/assets/1b163e80-fa0a-4072-baa4-d14b24b46ca3" />


## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [x] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [x] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [x] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
