### PR TITLE
Move link and information about original model to the InfoTooltip

### DIFF
--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/training/fine-tune-parameters.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/training/fine-tune-parameters.component.tsx
@@ -4,10 +4,10 @@
 import { FC } from 'react';
 
 import { Checkbox, Flex, Radio, RadioGroup } from '@geti/ui';
-import { Link } from 'react-router-dom';
 
 import { useDocsUrl } from '../../../../../../../hooks/use-docs-url/use-docs-url.hook';
 import { InfoTooltip } from '../../../../../../../shared/components/info-tooltip/info-tooltip.component';
+import { LinkNewTab } from '../../../../../../../shared/components/link-new-tab/link-new-tab.component';
 import { Accordion } from '../ui/accordion/accordion.component';
 
 import styles from './fine-tune-parameters.module.scss';
@@ -68,9 +68,7 @@ export const FineTuneParameters: FC<FineTuneParametersProps> = ({
                         <Radio value={TRAINING_WEIGHTS.PRE_TRAINED_WEIGHTS} marginEnd={'size-65'}>
                             Pre-trained weights - fine-tune the
                         </Radio>
-                        <Link to={originalModelUrl} className={styles.originalModelLink}>
-                            original model
-                        </Link>
+                        <LinkNewTab url={originalModelUrl} text='original model' className={styles.originalModelLink} />
                     </Flex>
                 </RadioGroup>
 

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/training/fine-tune-parameters.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/training/fine-tune-parameters.component.tsx
@@ -66,9 +66,25 @@ export const FineTuneParameters: FC<FineTuneParametersProps> = ({
                     </Radio>
                     <Flex alignItems={'center'}>
                         <Radio value={TRAINING_WEIGHTS.PRE_TRAINED_WEIGHTS} marginEnd={'size-65'}>
-                            Pre-trained weights - fine-tune the
+                            Pre-trained weights - fine-tune the original model
                         </Radio>
-                        <LinkNewTab url={originalModelUrl} text='original model' className={styles.originalModelLink} />
+                        <InfoTooltip
+                            tooltipText={
+                                // eslint-disable-next-line max-len
+                                <>
+                                    <span>
+                                        The original model is a base version with pre-trained weights, already trained
+                                        on a large, general-purpose dataset. It provides a strong foundation for
+                                        adapting to new, specific tasks.
+                                    </span>{' '}
+                                    <LinkNewTab
+                                        url={originalModelUrl}
+                                        text='Learn more.'
+                                        className={styles.originalModelLink}
+                                    />
+                                </>
+                            }
+                        />
                     </Flex>
                 </RadioGroup>
 

--- a/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/training/fine-tune-parameters.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-models/train-model-dialog/advanced-settings/training/fine-tune-parameters.component.tsx
@@ -70,7 +70,6 @@ export const FineTuneParameters: FC<FineTuneParametersProps> = ({
                         </Radio>
                         <InfoTooltip
                             tooltipText={
-                                // eslint-disable-next-line max-len
                                 <>
                                     <span>
                                         The original model is a base version with pre-trained weights, already trained


### PR DESCRIPTION
## 📝 Description

The problem with previous implementation was that when the link was clicked, it opened the user guide in the same tab as the app so whatever was set in the train dialog, was gone. 
I've added InfoTooltip and moved the link there with a short description of original model. Also now it openes in a new tab.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [x] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
