### PR TITLE
Bugfix: subset split configuration not applied during training [release 2.12]

### DIFF
--- a/interactive_ai/services/auto_train/app/job_creation_helpers.py
+++ b/interactive_ai/services/auto_train/app/job_creation_helpers.py
@@ -116,10 +116,10 @@ class TrainTaskJobData:
             "retain_training_artifacts": self.retain_training_artifacts,
         }
         if FeatureFlagProvider.is_enabled(FeatureFlag.FEATURE_FLAG_NEW_CONFIGURABLE_PARAMETERS):
-            payload["hyperparameters_json"] = (
+            payload["training_configuration_json"] = (
                 # Use model_dump_json to avoid int casting into floats
-                self.training_configuration.hyperparameters.model_dump_json(
-                    exclude={"training": {"allowed_values_input_size"}}, exclude_none=True
+                self.training_configuration.model_dump_json(
+                    exclude={"hyperparameters": {"training": {"allowed_values_input_size"}}}, exclude_none=True
                 )
                 if self.training_configuration
                 else None

--- a/interactive_ai/services/director/app/communication/kafka_handler.py
+++ b/interactive_ai/services/director/app/communication/kafka_handler.py
@@ -9,7 +9,6 @@ handling incoming Kafka events in the director MS.
 import logging
 import os
 from datetime import datetime
-from typing import TYPE_CHECKING
 
 from communication.exceptions import MissingJobPayloadAttribute
 from metrics.instruments import (
@@ -19,19 +18,26 @@ from metrics.instruments import (
 )
 from service.job_submission.job_creation_helpers import JobType
 from service.project_service import ProjectService
+from storage.repos.partial_training_configuration_repo import PartialTrainingConfigurationRepo
 
 from geti_kafka_tools import BaseKafkaHandler, KafkaRawMessage, TopicSubscription
 from geti_telemetry_tools import unified_tracing
 from geti_types import CTX_SESSION_VAR, ID, ProjectIdentifier, Singleton
+from iai_core.entities.model import Model
 from iai_core.entities.model_storage import ModelStorageIdentifier
 from iai_core.entities.model_test_result import TestState
-from iai_core.repos import ModelRepo, ModelStorageRepo, ModelTestResultRepo, TaskNodeRepo
+from iai_core.entities.subset import Subset
+from iai_core.repos import (
+    DatasetRepo,
+    DatasetStorageRepo,
+    ModelRepo,
+    ModelStorageRepo,
+    ModelTestResultRepo,
+    TaskNodeRepo,
+)
 from iai_core.session.session_propagation import setup_session_kafka
 from iai_core.utils.deletion_helpers import DeletionHelpers
 from iai_core.utils.type_helpers import str2bool
-
-if TYPE_CHECKING:
-    from iai_core.entities.model import Model
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +105,48 @@ class JobKafkaHandler(BaseKafkaHandler, metaclass=Singleton):
                 end_time=end_time,
                 job_status=TrainingDurationCounterJobStatus.SUCCEEDED,
             )
+
+            # update training subset proportions with values used in the training job
+            project_identifier = ProjectIdentifier(
+                workspace_id=workspace_id,
+                project_id=project_id,
+            )
+            self._update_subset_split_configuration(project_identifier=project_identifier, model=base_model)
+
+    @staticmethod
+    def _update_subset_split_configuration(project_identifier: ProjectIdentifier, model: Model) -> None:
+        """
+        Update the subset split configuration with actual values used after model training job.
+
+        :param project_identifier: The identifier of the project
+        :param model: The model containing the dataset information to update splits from
+        """
+        dataset_storage = DatasetStorageRepo(project_identifier).get_one(extra_filter={"use_for_training": True})
+        dataset_repo = DatasetRepo(dataset_storage.identifier)
+        subsets_count = dataset_repo.count_per_subset(dataset_id=model.train_dataset_id)
+        training_config_repo = PartialTrainingConfigurationRepo(project_identifier)
+        training_config = training_config_repo.get_by_model_manifest_id(
+            model_manifest_id=model.model_storage.model_manifest_id
+        )
+        n_training = subsets_count.get(Subset.TRAINING.name, 0)
+        n_validation = subsets_count.get(Subset.VALIDATION.name, 0)
+        n_test = subsets_count.get(Subset.TESTING.name, 0)
+
+        total = n_training + n_validation + n_test
+
+        # Calculate percentages (0-100 range)
+        validation_percent = int(100 * n_validation / total)
+        test_percent = int(100 * n_test / total)
+        # Ensure percentages sum to exactly 100
+        training_percent = 100 - validation_percent - test_percent
+
+        # Update the configuration with percentages
+        training_config.global_parameters.dataset_preparation.subset_split.training = training_percent
+        training_config.global_parameters.dataset_preparation.subset_split.validation = validation_percent
+        training_config.global_parameters.dataset_preparation.subset_split.test = test_percent
+
+        # Save the updated configuration
+        training_config_repo.save(training_config)
 
     @setup_session_kafka
     @unified_tracing

--- a/interactive_ai/services/director/app/communication/kafka_handler.py
+++ b/interactive_ai/services/director/app/communication/kafka_handler.py
@@ -134,11 +134,20 @@ class JobKafkaHandler(BaseKafkaHandler, metaclass=Singleton):
 
         total = n_training + n_validation + n_test
 
-        # Calculate percentages (0-100 range)
-        validation_percent = int(100 * n_validation / total)
-        test_percent = int(100 * n_test / total)
-        # Ensure percentages sum to exactly 100
-        training_percent = 100 - validation_percent - test_percent
+        if total == 0:
+            logger.warning(
+                f"Cannot update subset split configuration for project {project_identifier}: "
+                "total number of samples is zero. Setting all split percentages to zero."
+            )
+            training_percent = 0
+            validation_percent = 0
+            test_percent = 0
+        else:
+            # Calculate percentages (0-100 range)
+            validation_percent = int(100 * n_validation / total)
+            test_percent = int(100 * n_test / total)
+            # Ensure percentages sum to exactly 100
+            training_percent = 100 - validation_percent - test_percent
 
         # Update the configuration with percentages
         training_config.global_parameters.dataset_preparation.subset_split.training = training_percent

--- a/interactive_ai/services/director/app/service/job_submission/job_creation_helpers.py
+++ b/interactive_ai/services/director/app/service/job_submission/job_creation_helpers.py
@@ -162,10 +162,10 @@ class TrainTaskJobData:
             "retain_training_artifacts": self.retain_training_artifacts,
         }
         if FeatureFlagProvider.is_enabled(FeatureFlag.FEATURE_FLAG_NEW_CONFIGURABLE_PARAMETERS):
-            payload["hyperparameters_json"] = (
+            payload["training_configuration_json"] = (
                 # Use model_dump_json to avoid int casting into floats
-                self.training_configuration.hyperparameters.model_dump_json(
-                    exclude={"training": {"allowed_values_input_size"}}, exclude_none=True
+                self.training_configuration.model_dump_json(
+                    exclude={"hyperparameters": {"training": {"allowed_values_input_size"}}}, exclude_none=True
                 )
                 if self.training_configuration
                 else None

--- a/interactive_ai/services/director/tests/fixtures/training_configuration.py
+++ b/interactive_ai/services/director/tests/fixtures/training_configuration.py
@@ -210,7 +210,7 @@ def fxt_training_configuration_task_level_rest_view(fxt_training_configuration_t
                     "value": 10,
                 },
                 {
-                    "default_value": True,
+                    "default_value": False,
                     "description": "Whether to automatically select data for each subset",
                     "key": "auto_selection",
                     "name": "Auto selection",
@@ -503,7 +503,7 @@ def fxt_training_configuration_full_rest_view(
                     "value": 10,
                 },
                 {
-                    "default_value": True,
+                    "default_value": False,
                     "description": "Whether to automatically select data for each subset",
                     "key": "auto_selection",
                     "name": "Auto selection",

--- a/interactive_ai/workflows/common/jobs_common/utils/dataset_helpers.py
+++ b/interactive_ai/workflows/common/jobs_common/utils/dataset_helpers.py
@@ -5,6 +5,7 @@
 import copy
 import os
 
+from geti_configuration_tools.training_configuration import TrainingConfiguration
 from geti_kafka_tools import publish_event
 from geti_telemetry_tools import unified_tracing
 from geti_types import CTX_SESSION_VAR, ID, DatasetStorageIdentifier, ProjectIdentifier
@@ -211,6 +212,7 @@ class DatasetHelpers:
         project_id: ID,
         task_node: TaskNode,
         dataset_storage: DatasetStorage,
+        training_configuration: TrainingConfiguration,
         max_training_dataset_size: int | None = None,
         reshuffle_subsets: bool = False,
     ) -> Dataset:
@@ -225,6 +227,7 @@ class DatasetHelpers:
         :param project_id: ID of the project
         :param task_node: Task node for which the dataset is fetched
         :param dataset_storage: DatasetStorage containing the dataset items
+        :param training_configuration: Training configuration containing dataset preparation parameters
         :param max_training_dataset_size: maximum training dataset size
         :param reshuffle_subsets: Whether to reassign/shuffle all the items to subsets including Test set from scratch
         :return: A copy of the current dataset, split into subsets.
@@ -253,6 +256,8 @@ class DatasetHelpers:
         TaskSubsetManager.split(
             dataset_items=iter(training_dataset_items),
             task_node=task_node,
+            subset_split_config=training_configuration.global_parameters.dataset_preparation.subset_split,
+            filtering_config=training_configuration.global_parameters.dataset_preparation.filtering,
             subsets_to_reset=subsets_to_reset,
         )
         task_dataset_entity.save_subsets(dataset=dataset, dataset_storage_identifier=dataset_storage.identifier)

--- a/interactive_ai/workflows/common/jobs_common/utils/subset_management/subset_manager.py
+++ b/interactive_ai/workflows/common/jobs_common/utils/subset_management/subset_manager.py
@@ -320,7 +320,7 @@ class _SubsetHelper:
         """
         if self.subset_split_config.auto_selection:
             # Determine fractions automatically
-            logger.info(f"Determine fractions automatically: {self.subset_split_config.auto_selection}")
+            logger.debug(f"Determine fractions automatically: {self.subset_split_config.auto_selection}")
             if self.number_of_annotations < SplitTargetSize.SMALL:
                 ratios = TARGET_SMALL
             elif self.number_of_annotations < SplitTargetSize.MEDIUM:

--- a/interactive_ai/workflows/common/jobs_common/utils/subset_management/subset_manager.py
+++ b/interactive_ai/workflows/common/jobs_common/utils/subset_management/subset_manager.py
@@ -11,18 +11,15 @@ import random
 from collections.abc import Iterable, Iterator, Sequence
 
 import numpy as np
+from geti_configuration_tools.training_configuration import Filtering, SubsetSplit
 from geti_telemetry_tools import unified_tracing
 from geti_types import CTX_SESSION_VAR, ID, ProjectIdentifier
-from iai_core.configuration.elements.component_parameters import ComponentParameters, ComponentType
 from iai_core.entities.dataset_item import DatasetItem
 from iai_core.entities.label import Label
 from iai_core.entities.subset import Subset
 from iai_core.entities.task_node import TaskNode
-from iai_core.repos import ConfigurableParametersRepo
 from iai_core.utils.dataset_helper import DatasetHelper
 from iai_core.utils.type_helpers import SequenceOrSet
-
-from .subset_manager_config import SubsetManagerConfig
 
 logger = logging.getLogger(__name__)
 
@@ -75,13 +72,15 @@ class _SubsetHelper:
         self,
         task_node: TaskNode,
         task_labels: list[Label],
-        config: ComponentParameters[SubsetManagerConfig],
+        subset_split_config: SubsetSplit,
+        filtering_config: Filtering | None = None,
     ) -> None:
         self.task = task_node
         self.latest_task_labels = task_labels
         self.latest_task_label_ids = [label.id_ for label in task_labels]
         self.latest_task_label_map = {label.id_: label for label in task_labels}
-        self.config = config
+        self.subset_split_config = subset_split_config
+        self.filtering_config = filtering_config
 
         self.subset_counter = np.zeros(len(SUBSETS))
         self.subset_label_counter = np.zeros((len(SUBSETS), len(self.latest_task_labels)))
@@ -319,8 +318,9 @@ class _SubsetHelper:
 
         :return: Dictionary where: ratios[subset] = ratio for subset
         """
-        if self.config.auto_subset_fractions:
+        if self.subset_split_config.auto_selection:
             # Determine fractions automatically
+            logger.info(f"Determine fractions automatically: {self.subset_split_config.auto_selection}")
             if self.number_of_annotations < SplitTargetSize.SMALL:
                 ratios = TARGET_SMALL
             elif self.number_of_annotations < SplitTargetSize.MEDIUM:
@@ -331,9 +331,9 @@ class _SubsetHelper:
             # In case manual definition is required, use values from the configuration
             ratios = np.array(
                 [
-                    self.config.subset_parameters.train_proportion,
-                    self.config.subset_parameters.validation_proportion,
-                    self.config.subset_parameters.test_proportion,
+                    self.subset_split_config.training / 100,
+                    self.subset_split_config.validation / 100,
+                    self.subset_split_config.test / 100,
                 ]
             )
             if not math.isclose(a=np.sum(ratios), b=1.0, rel_tol=1e-6):
@@ -472,8 +472,8 @@ class _AnomalySubsetHelper(_SubsetHelper):
         """
         normal_ratios = super().compute_target_ratios()
 
-        val_proportion = self.config.subset_parameters.validation_proportion / (
-            self.config.subset_parameters.test_proportion + self.config.subset_parameters.validation_proportion
+        val_proportion = self.subset_split_config.validation / (
+            self.subset_split_config.test + self.subset_split_config.validation
         )
         test_proportion = 1 - val_proportion
         anomaly_ratios = [[0], [val_proportion], [test_proportion]]
@@ -518,6 +518,8 @@ class TaskSubsetManager(ITaskSubsetManager):
     def split(
         dataset_items: Iterator[DatasetItem],
         task_node: TaskNode,
+        subset_split_config: SubsetSplit,
+        filtering_config: Filtering | None = None,
         subsets_to_reset: tuple[Subset, ...] | None = None,
     ) -> None:
         """
@@ -525,6 +527,7 @@ class TaskSubsetManager(ITaskSubsetManager):
 
         :param dataset_items: Dataset items to split
         :param task_node: TaskNode for which to split the dataset
+        :param subset_split_config: Configuration for the subset split
         :param subsets_to_reset: Tuple of subsets to reset. The dataset items assigned to these subsets will be
             unassigned before getting split into subsets. If None, no subsets will be reset.
         """
@@ -535,26 +538,23 @@ class TaskSubsetManager(ITaskSubsetManager):
             task_node_id=task_node.id_,
             include_empty=True,
         )
-        config_param_repo = ConfigurableParametersRepo(project_identifier)
-        config = config_param_repo.get_or_create_component_parameters(
-            data_instance_of=SubsetManagerConfig,
-            component=ComponentType.SUBSET_MANAGER,
-            task_id=task_node.id_,
-        )
         subset_helper_type = _AnomalySubsetHelper if task_node.task_properties.is_anomaly else _SubsetHelper
         subset_helper = subset_helper_type(
             task_node=task_node,
             task_labels=task_labels,
-            config=config,
+            subset_split_config=subset_split_config,
+            filtering_config=filtering_config,
         )
 
         # Determine subsets for resetting based on task type and configuration
-        if not task_node.task_properties.is_anomaly and config.train_validation_remixing:
+        if not task_node.task_properties.is_anomaly and subset_split_config.remixing:
             # if train_validation_remixing is enabled, we need to reset the training and validation subsets
             # if subsets_to_reset is not empty, then we take a union of the subsets to reset
             subsets_to_reset = tuple(set(subsets_to_reset or []) | {Subset.TRAINING, Subset.VALIDATION})
 
         logger.info(f"Splitting dataset for task {task_node.id_} into subsets. Subsets to reset: {subsets_to_reset}")
+        logger.info(f"Subset split config: {subset_split_config}")
+        logger.info(f"Filtering config: {filtering_config}")
 
         subset_helper.split(
             dataset_items=dataset_items,

--- a/interactive_ai/workflows/common/tests/fixtures/configuration.py
+++ b/interactive_ai/workflows/common/tests/fixtures/configuration.py
@@ -3,6 +3,27 @@
 
 import pytest
 from attr import attrs
+from geti_configuration_tools.hyperparameters import (
+    AugmentationParameters,
+    CenterCrop,
+    DatasetPreparationParameters,
+    EarlyStopping,
+    EvaluationParameters,
+    Hyperparameters,
+    TrainingHyperParameters,
+)
+from geti_configuration_tools.training_configuration import (
+    Filtering,
+    GlobalDatasetPreparationParameters,
+    GlobalParameters,
+    MaxAnnotationObjects,
+    MaxAnnotationPixels,
+    MinAnnotationObjects,
+    MinAnnotationPixels,
+    SubsetSplit,
+    TrainingConfiguration,
+)
+from geti_types import ID
 from iai_core.configuration.elements.configurable_parameters import ConfigurableParameters
 from iai_core.configuration.elements.default_model_parameters import DefaultModelParameters
 from iai_core.configuration.elements.hyper_parameters import HyperParameters
@@ -68,4 +89,52 @@ def fxt_hyper_parameters_with_groups(fxt_model_storage, fxt_mongo_id):
         model_storage_id=fxt_model_storage.id_,
         data=DummyHyperParameters(),
         id_=fxt_mongo_id(2),
+    )
+
+
+@pytest.fixture
+def ftx_hyperparameters():
+    yield Hyperparameters(
+        dataset_preparation=DatasetPreparationParameters(
+            augmentation=AugmentationParameters(
+                center_crop=CenterCrop(enable=True, ratio=0.6),
+            )
+        ),
+        training=TrainingHyperParameters(
+            max_epochs=100,
+            early_stopping=EarlyStopping(enable=True, patience=10),
+            learning_rate=0.001,
+        ),
+        evaluation=EvaluationParameters(),
+    )
+
+
+@pytest.fixture
+def fxt_global_parameters():
+    yield GlobalParameters(
+        dataset_preparation=GlobalDatasetPreparationParameters(
+            subset_split=SubsetSplit(
+                training=70,
+                validation=20,
+                test=10,
+                auto_selection=True,
+                remixing=False,
+            ),
+            filtering=Filtering(
+                min_annotation_pixels=MinAnnotationPixels(enable=True, min_annotation_pixels=10),
+                max_annotation_pixels=MaxAnnotationPixels(enable=True, max_annotation_pixels=1000),
+                min_annotation_objects=MinAnnotationObjects(enable=True, min_annotation_objects=5),
+                max_annotation_objects=MaxAnnotationObjects(enable=True, max_annotation_objects=100),
+            ),
+        )
+    )
+
+
+@pytest.fixture
+def fxt_training_configuration(fxt_global_parameters, ftx_hyperparameters):
+    yield TrainingConfiguration(
+        id_=ID("training_config_id"),
+        task_id="task_123",
+        global_parameters=fxt_global_parameters,
+        hyperparameters=ftx_hyperparameters,
     )

--- a/interactive_ai/workflows/common/tests/unit/utils/subset_management/test_subset_manager_unit.py
+++ b/interactive_ai/workflows/common/tests/unit/utils/subset_management/test_subset_manager_unit.py
@@ -5,7 +5,6 @@ from unittest.mock import call, patch
 
 import numpy as np
 import pytest
-from iai_core.configuration.elements.configurable_parameters import ConfigurableParameters
 from iai_core.entities.datasets import Dataset
 from iai_core.entities.subset import Subset
 
@@ -30,7 +29,7 @@ class TestSubsetHelper:
         self,
         fxt_task,
         fxt_label,
-        fxt_configuration,
+        fxt_training_configuration,
         fxt_dataset,
         fxt_dataset_item,
     ) -> None:
@@ -46,7 +45,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
 
             subset_helper.split(dataset_items=fxt_dataset)
@@ -64,7 +64,7 @@ class TestSubsetHelper:
         self,
         fxt_task,
         fxt_label,
-        fxt_configuration,
+        fxt_training_configuration,
         fxt_dataset_item,
         fxt_mongo_id,
     ) -> None:
@@ -83,7 +83,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
 
             subset_helper.split(dataset_items=dataset)
@@ -94,7 +95,7 @@ class TestSubsetHelper:
             mock_reorder.assert_called_once_with(training_dataset_items=list(dataset))
             mock_assign.assert_has_calls([call(item=item) for item in dataset if item.subset in SUBSETS])
 
-    def test_update_deficiencies(self, fxt_task, fxt_label, fxt_configuration) -> None:
+    def test_update_deficiencies(self, fxt_task, fxt_label, fxt_training_configuration) -> None:
         with (
             patch.object(_SubsetHelper, "__init__", new=do_nothing),
             patch.object(_SubsetHelper, "compute_actual_ratios", return_value=np.zeros(1)) as mock_compute_ratios,
@@ -103,7 +104,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
 
             subset_helper.update_deficiencies(subset_label_counter=np.zeros(2))
@@ -124,13 +126,14 @@ class TestSubsetHelper:
         fxt_label,
         param_fxt_subset_counter,
         param_fxt_ratios,
-        fxt_configuration,
+        fxt_training_configuration,
     ):
         with patch.object(_SubsetHelper, "__init__", new=do_nothing):
             subset_helper = _SubsetHelper(
                 task_node=fxt_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
 
             result = subset_helper.compute_actual_ratios(subset_counter=param_fxt_subset_counter)
@@ -151,7 +154,7 @@ class TestSubsetHelper:
         self,
         fxt_task,
         fxt_label,
-        fxt_configuration,
+        fxt_training_configuration,
         param_fxt_actual_ratios,
         param_fxt_deficiencies,
     ) -> None:
@@ -159,7 +162,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.target_ratios = np.array([0.5, 0.25, 0.25])
 
@@ -171,7 +175,7 @@ class TestSubsetHelper:
         self,
         fxt_classification_task,
         fxt_label,
-        fxt_configuration,
+        fxt_training_configuration,
         fxt_dataset_item,
     ) -> None:
         dataset_item = fxt_dataset_item()
@@ -180,7 +184,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_classification_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.task = fxt_classification_task
 
@@ -192,7 +197,7 @@ class TestSubsetHelper:
         self,
         fxt_detection_task,
         fxt_label,
-        fxt_configuration,
+        fxt_training_configuration,
         fxt_dataset_item,
     ) -> None:
         dataset_item = fxt_dataset_item()
@@ -200,7 +205,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_detection_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.task = fxt_detection_task
 
@@ -208,7 +214,9 @@ class TestSubsetHelper:
 
             assert result == {fxt_label.id_}
 
-    def test_assign_item_to_subset_empty_subset(self, fxt_task, fxt_label, fxt_configuration, fxt_dataset_item) -> None:
+    def test_assign_item_to_subset_empty_subset(
+        self, fxt_task, fxt_label, fxt_training_configuration, fxt_dataset_item
+    ) -> None:
         dataset_item = fxt_dataset_item()
         with (
             patch.object(_SubsetHelper, "__init__", new=do_nothing),
@@ -217,7 +225,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.task = fxt_task
             subset_helper.subset_counter = np.array([0, 1, 1])
@@ -229,7 +238,7 @@ class TestSubsetHelper:
             assert dataset_item.subset == Subset.TRAINING
 
     def test_assign_item_to_subset_no_empty_subset(
-        self, fxt_task, fxt_label, fxt_configuration, fxt_dataset_item
+        self, fxt_task, fxt_label, fxt_training_configuration, fxt_dataset_item
     ) -> None:
         dataset_item = fxt_dataset_item()
         with (
@@ -242,7 +251,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.task = fxt_task
             subset_helper.subset_counter = np.array([10, 1, 10])
@@ -261,7 +271,7 @@ class TestSubsetHelper:
         self,
         fxt_detection_task,
         fxt_label,
-        fxt_configuration,
+        fxt_training_configuration,
         fxt_dataset_item,
     ) -> None:
         dataset_item = fxt_dataset_item()
@@ -273,7 +283,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_detection_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.task = fxt_detection_task
             subset_helper.subset_label_counter = np.array([[0, 0, 0]])
@@ -285,7 +296,7 @@ class TestSubsetHelper:
             assert np.array_equal(subset_helper.subset_counter, np.array([1, 0, 0]))
             assert np.array_equal(subset_helper.subset_label_counter, np.array([[1, 0, 0]]))
 
-    def test_compute_potential_deficiency(self, fxt_detection_task, fxt_label, fxt_configuration) -> None:
+    def test_compute_potential_deficiency(self, fxt_detection_task, fxt_label, fxt_training_configuration) -> None:
         with (
             patch.object(_SubsetHelper, "__init__", new=do_nothing),
             patch.object(
@@ -300,7 +311,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_detection_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.subset_label_counter = np.array([[7, 1, 1]])
             subset_helper.labels_to_index = {fxt_label.id_: 0}
@@ -324,7 +336,7 @@ class TestSubsetHelper:
         self,
         fxt_detection_task,
         fxt_label,
-        fxt_configuration,
+        fxt_training_configuration,
         param_fxt_n_annotations,
         param_fxt_auto_subset_fractions,
         param_fxt_expected_ratios,
@@ -337,21 +349,26 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_detection_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
-            fxt_configuration.auto_subset_fractions = param_fxt_auto_subset_fractions
-            fxt_configuration.subset_parameters = ConfigurableParameters(header="subset_parameters")
-            fxt_configuration.subset_parameters.train_proportion = 1  # type: ignore
-            fxt_configuration.subset_parameters.validation_proportion = 0  # type: ignore
-            fxt_configuration.subset_parameters.test_proportion = 0  # type: ignore
-            subset_helper.config = fxt_configuration
+            fxt_training_configuration.global_parameters.dataset_preparation.subset_split.training = 100
+            fxt_training_configuration.global_parameters.dataset_preparation.subset_split.validation = 0
+            fxt_training_configuration.global_parameters.dataset_preparation.subset_split.test = 0
+            fxt_training_configuration.global_parameters.dataset_preparation.subset_split.auto_selection = (
+                param_fxt_auto_subset_fractions
+            )
+            subset_helper.subset_split_config = (
+                fxt_training_configuration.global_parameters.dataset_preparation.subset_split
+            )
+            subset_helper.filtering_config = fxt_training_configuration.global_parameters.dataset_preparation.filtering
             subset_helper.number_of_annotations = param_fxt_n_annotations
 
             result = subset_helper.compute_target_ratios()
 
             assert np.array_equal(result, param_fxt_expected_ratios[:, np.newaxis])
 
-    def test_reorder_by_priority(self, fxt_task, fxt_label, fxt_configuration, fxt_dataset_item) -> None:
+    def test_reorder_by_priority(self, fxt_task, fxt_label, fxt_training_configuration, fxt_dataset_item) -> None:
         dataset_item_1 = fxt_dataset_item(0)
         dataset_item_2 = fxt_dataset_item(1)
         dataset_items = [dataset_item_1, dataset_item_2]
@@ -366,7 +383,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.task = fxt_task
             subset_helper.subset_counter = np.array([0, 1, 1])
@@ -383,7 +401,7 @@ class TestSubsetHelper:
         fxt_detection_task,
         fxt_label,
         fxt_label_2,
-        fxt_configuration,
+        fxt_training_configuration,
         fxt_dataset_item,
     ) -> None:
         dataset_item_1 = fxt_dataset_item(0)
@@ -400,7 +418,8 @@ class TestSubsetHelper:
             subset_helper = _SubsetHelper(
                 task_node=fxt_detection_task,
                 task_labels=[fxt_label, fxt_label_2],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.labels_to_index = {fxt_label.id_: 0, fxt_label_2.id_: 1}
             subset_helper.latest_task_labels = [fxt_label, fxt_label_2]
@@ -431,7 +450,7 @@ class TestAnomalySubsetHelper:
         self,
         fxt_anomaly_task,
         fxt_label,
-        fxt_configuration,
+        fxt_training_configuration,
         fxt_anomalous_label,
         fxt_anomaly_dataset_item_normal_annotation,
     ) -> None:
@@ -447,7 +466,8 @@ class TestAnomalySubsetHelper:
             subset_helper = _AnomalySubsetHelper(
                 task_node=fxt_anomaly_task,
                 task_labels=[fxt_label, fxt_anomalous_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.task = fxt_anomaly_task
             subset_helper.subset_label_counter = np.array([[0, 0, 0], [0, 0, 0]])
@@ -471,7 +491,7 @@ class TestAnomalySubsetHelper:
         self,
         fxt_anomaly_task,
         fxt_label,
-        fxt_configuration,
+        fxt_training_configuration,
         fxt_anomalous_label,
         fxt_anomaly_dataset_item_anomalous_annotation,
     ) -> None:
@@ -487,7 +507,8 @@ class TestAnomalySubsetHelper:
             subset_helper = _AnomalySubsetHelper(
                 task_node=fxt_anomaly_task,
                 task_labels=[fxt_label, fxt_anomalous_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.task = fxt_anomaly_task
             subset_helper.subset_label_counter = np.array([[0, 0, 0], [0, 0, 0]])
@@ -512,7 +533,7 @@ class TestAnomalySubsetHelper:
         fxt_task,
         fxt_label,
         fxt_anomalous_label,
-        fxt_configuration,
+        fxt_training_configuration,
         fxt_dataset_item,
     ) -> None:
         """
@@ -532,7 +553,8 @@ class TestAnomalySubsetHelper:
             subset_helper = _AnomalySubsetHelper(
                 task_node=fxt_task,
                 task_labels=[fxt_label, fxt_anomalous_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
             subset_helper.task = fxt_task
             subset_helper.subset_label_counter = np.array([[10, 2, 10], [10, 2, 10]])
@@ -555,19 +577,22 @@ class TestAnomalySubsetHelper:
             mock_count_item.assert_called_once_with(item=dataset_item, item_label_ids={fxt_label.id_})
             assert dataset_item.subset == Subset.VALIDATION
 
-    def test_compute_target_ratios(self, fxt_detection_task, fxt_label, fxt_configuration) -> None:
+    def test_compute_target_ratios(self, fxt_detection_task, fxt_label, fxt_training_configuration) -> None:
         with patch.object(_AnomalySubsetHelper, "__init__", new=do_nothing):
             subset_helper = _AnomalySubsetHelper(
                 task_node=fxt_detection_task,
                 task_labels=[fxt_label],
-                config=fxt_configuration,
+                subset_split_config=fxt_training_configuration.global_parameters.dataset_preparation.subset_split,
+                filtering_config=fxt_training_configuration.global_parameters.dataset_preparation.filtering,
             )
-            fxt_configuration.subset_parameters = ConfigurableParameters(header="subset_parameters")
-            fxt_configuration.subset_parameters.train_proportion = 0.8  # type: ignore
-            fxt_configuration.subset_parameters.validation_proportion = 0.1  # type: ignore
-            fxt_configuration.subset_parameters.test_proportion = 0.1  # type: ignore
-            fxt_configuration.auto_subset_fractions = False
-            subset_helper.config = fxt_configuration
+            fxt_training_configuration.global_parameters.dataset_preparation.subset_split.training = 80
+            fxt_training_configuration.global_parameters.dataset_preparation.subset_split.validation = 10
+            fxt_training_configuration.global_parameters.dataset_preparation.subset_split.test = 10
+            fxt_training_configuration.global_parameters.dataset_preparation.subset_split.auto_selection = False
+            subset_helper.subset_split_config = (
+                fxt_training_configuration.global_parameters.dataset_preparation.subset_split
+            )
+            subset_helper.filtering_config = fxt_training_configuration.global_parameters.dataset_preparation.filtering
 
             result = subset_helper._compute_target_ratios()
 

--- a/interactive_ai/workflows/common/tests/unit/utils/test_dataset_helpers.py
+++ b/interactive_ai/workflows/common/tests/unit/utils/test_dataset_helpers.py
@@ -20,6 +20,7 @@ class TestDatasetHelpers:
         fxt_video_factory,
         fxt_video_frame_entity_factory,
         fxt_annotation_scene,
+        fxt_training_configuration,
     ) -> None:
         project: Project = fxt_detection_project
         task_node = project.get_trainable_task_nodes()[0]
@@ -53,6 +54,7 @@ class TestDatasetHelpers:
                 project_id=project.id_,
                 task_node=task_node,
                 dataset_storage=dataset_storage,
+                training_configuration=fxt_training_configuration,
                 max_training_dataset_size=1000,
                 reshuffle_subsets=True,
             )

--- a/interactive_ai/workflows/train/job/commands/create_task_train_dataset_command.py
+++ b/interactive_ai/workflows/train/job/commands/create_task_train_dataset_command.py
@@ -5,6 +5,7 @@
 
 import logging
 
+from geti_configuration_tools.training_configuration import TrainingConfiguration
 from geti_telemetry_tools import unified_tracing
 from iai_core.entities.dataset_storage import DatasetStorage
 from iai_core.entities.datasets import Dataset, NullDataset
@@ -25,6 +26,7 @@ class CreateTaskTrainDatasetCommand(CreateDatasetCommand):
     :param project: project containing dataset storage
     :param dataset_storage: dataset storage containing media and annotations
     :param task_node: Task containing the command
+    :param training_configuration: training configuration for the task
     :param max_training_dataset_size: maximum training dataset size
     :param reshuffle_subsets: Whether to reassign/shuffle all the items to subsets including Test set from scratch
     """
@@ -34,6 +36,7 @@ class CreateTaskTrainDatasetCommand(CreateDatasetCommand):
         project: Project,
         dataset_storage: DatasetStorage,
         task_node: TaskNode,
+        training_configuration: TrainingConfiguration,
         max_training_dataset_size: int | None = None,
         reshuffle_subsets: bool = False,
     ) -> None:
@@ -42,6 +45,7 @@ class CreateTaskTrainDatasetCommand(CreateDatasetCommand):
         self.dataset: Dataset = NullDataset()
         self.max_training_dataset_size = max_training_dataset_size
         self.reshuffle_subsets = reshuffle_subsets
+        self.training_configuration = training_configuration
 
     @unified_tracing
     def execute(self) -> None:
@@ -63,6 +67,7 @@ class CreateTaskTrainDatasetCommand(CreateDatasetCommand):
                 project_id=self.project.id_,
                 task_node=self.task_node,
                 dataset_storage=self.dataset_storage,
+                training_configuration=self.training_configuration,
                 max_training_dataset_size=self.max_training_dataset_size,
                 reshuffle_subsets=self.reshuffle_subsets,
             )

--- a/interactive_ai/workflows/train/job/tasks/prepare_and_train/create_task_train_dataset.py
+++ b/interactive_ai/workflows/train/job/tasks/prepare_and_train/create_task_train_dataset.py
@@ -33,6 +33,7 @@ def create_task_train_dataset(
         project=project,
         dataset_storage=dataset_storage,
         task_node=task_node,
+        training_configuration=train_data.training_configuration,
         max_training_dataset_size=max_training_dataset_size,
         reshuffle_subsets=train_data.reshuffle_subsets,
     )

--- a/interactive_ai/workflows/train/job/tasks/prepare_and_train/get_train_data.py
+++ b/interactive_ai/workflows/train/job/tasks/prepare_and_train/get_train_data.py
@@ -35,7 +35,7 @@ def get_train_data(  # noqa: PLR0913
     min_annotation_size: int | None = None,
     max_number_of_annotations: int | None = None,
     reshuffle_subsets: bool = False,
-    hyperparameters_json: str | None = None,
+    training_configuration_json: str | None = None,
 ) -> TrainWorkflowData:
     """
     Create and return a TrainWorkflowData object containing data needed for training
@@ -53,7 +53,7 @@ def get_train_data(  # noqa: PLR0913
     :param max_number_of_annotations: Maximum number of annotation allowed in one annotation scene. If exceeded, the
         annotation scene will be ignored during training.
     :param reshuffle_subsets: Whether to reassign/shuffle all the items to subsets including Test set from scratch
-    :param hyperparameters_json: JSON string containing the hyperparameters to be used for training.
+    :param training_configuration_json: JSON string containing the training configuration, including hyperparameters.
     :return: TrainWorkflowData object containing the data needed for training
     """
     # Validate task is in project
@@ -106,5 +106,5 @@ def get_train_data(  # noqa: PLR0913
         min_annotation_size=min_annotation_size,
         max_number_of_annotations=max_number_of_annotations,
         reshuffle_subsets=reshuffle_subsets,
-        hyperparameters_json=hyperparameters_json,
+        training_configuration_json=training_configuration_json,
     )

--- a/interactive_ai/workflows/train/job/tasks/prepare_and_train/prepare_data_and_train.py
+++ b/interactive_ai/workflows/train/job/tasks/prepare_and_train/prepare_data_and_train.py
@@ -107,7 +107,7 @@ def prepare_training_data_model_and_start_training(  # noqa: PLR0913
     min_annotation_size: typing.Optional[int] = None,  # noqa: UP007
     max_number_of_annotations: typing.Optional[int] = None,  # noqa: UP007
     reshuffle_subsets: bool = False,
-    hyperparameters_json: typing.Optional[str] = None,  # noqa: UP007
+    training_configuration_json: typing.Optional[str] = None,  # noqa: UP007
 ) -> TrainWorkflowDataForFlyteTaskTrainer:
     """
     Prepare data and model for the consecutive model training Flyte task.
@@ -131,7 +131,7 @@ def prepare_training_data_model_and_start_training(  # noqa: PLR0913
     :param max_number_of_annotations: Maximum number of annotation allowed in one annotation scene. If exceeded, the
     annotation scene will be ignored during training.
     :param reshuffle_subsets: Whether to reassign/shuffle all the items to subsets including Test set from scratch
-    :param hyperparameters_json: JSON string containing the hyperparameters to be used for training.
+    :param training_configuration_json: JSON string containing the training configuration, including hyperparameters.
     :return TrainWorkflowDataForFlyteTaskTrainer: train workflow data class and others needed
         the next model training Flyte task.
     """
@@ -161,7 +161,7 @@ def prepare_training_data_model_and_start_training(  # noqa: PLR0913
         min_annotation_size=min_annotation_size,
         max_number_of_annotations=max_number_of_annotations,
         reshuffle_subsets=reshuffle_subsets,
-        hyperparameters_json=hyperparameters_json,
+        training_configuration_json=training_configuration_json,
     )
     report_retrieve_train_data_progress(progress=100, message="Train data retrieved")
 

--- a/interactive_ai/workflows/train/job/tasks/prepare_and_train/train_helpers.py
+++ b/interactive_ai/workflows/train/job/tasks/prepare_and_train/train_helpers.py
@@ -220,11 +220,15 @@ def prepare_train(train_data: TrainWorkflowData, dataset: Dataset) -> TrainOutpu
     label_schema = train_data.get_label_schema()
     model_storage = train_data.get_model_storage()
     input_model = train_data.get_input_model()
-    legacy_hyper_parameters = train_data.get_hyper_parameters()
+    legacy_hyper_parameters = train_data.get_legacy_hyper_parameters()
 
     model_repo = ModelRepo(model_storage.identifier)
     model_version = model_repo.get_latest_successful_version() + 1
-    revamped_hyperparameters = json.loads(train_data.hyperparameters_json) if train_data.hyperparameters_json else None
+    revamped_hyperparameters = (
+        json.loads(train_data.training_configuration_json).get("hyperparameters")
+        if train_data.training_configuration_json
+        else None
+    )
     model_builder = _ModelBuilder(
         model_repo=model_repo,
         project=project,

--- a/interactive_ai/workflows/train/job/utils/train_workflow_data.py
+++ b/interactive_ai/workflows/train/job/utils/train_workflow_data.py
@@ -5,10 +5,12 @@
 Defines train workflow data and getter utils
 """
 
+import json
 import typing
 from dataclasses import dataclass
 
 from dataclasses_json import dataclass_json
+from geti_configuration_tools.training_configuration import TrainingConfiguration
 from geti_types import ID, DatasetStorageIdentifier, ProjectIdentifier
 from iai_core.configuration.elements.hyper_parameters import HyperParameters
 from iai_core.entities.compiled_dataset_shards import CompiledDatasetShards, NullCompiledDatasetShards
@@ -45,7 +47,7 @@ class TrainWorkflowData:
     :param max_number_of_annotations: Maximum number of annotation allowed in one annotation scene. If exceeded, the
     annotation scene will be ignored during training.
     :param reshuffle_subsets: Whether to reassign/shuffle all the items to subsets including Test set from scratch
-    :param hyperparameters: JSON string containing the hyperparameters to be used for training.
+    :param training_configuration_json: JSON string containing the training configuration, including hyperparameters.
     """
 
     workspace_id: str
@@ -63,7 +65,7 @@ class TrainWorkflowData:
     min_annotation_size: typing.Optional[int] = None  # noqa: UP007
     max_number_of_annotations: typing.Optional[int] = None  # noqa: UP007
     reshuffle_subsets: bool = False
-    hyperparameters_json: typing.Optional[str] = None  # noqa: UP007
+    training_configuration_json: typing.Optional[str] = None  # noqa: UP007
 
     def get_common_entities(self) -> tuple[Project, TaskNode]:
         """
@@ -145,7 +147,7 @@ class TrainWorkflowData:
         repo = CompiledDatasetShardsRepo(dataset_storage_identifier=dataset_storage_identifier)
         return repo.get_by_id(id_=ID(self.compiled_dataset_shards_id))
 
-    def get_hyper_parameters(self) -> HyperParameters:
+    def get_legacy_hyper_parameters(self) -> HyperParameters:
         """Get the HyperParameters entity.
 
         :return HyperParameters: Return HyperParameters entity from given hyperparameters_id and project_id
@@ -153,6 +155,20 @@ class TrainWorkflowData:
         project = ProjectRepo().get_by_id(ID(self.project_id))
         config_params_repo = ConfigurableParametersRepo(project.identifier)
         return typing.cast("HyperParameters", config_params_repo.get_by_id(ID(self.hyperparameters_id)))
+
+    @property
+    def training_configuration(self) -> TrainingConfiguration:
+        """Get the TrainingConfiguration entity.
+
+        :return TrainingConfiguration: Return TrainingConfiguration entity from given training_configuration_json
+        """
+        if self.training_configuration_json is None:
+            raise ValueError("Training configuration JSON is not set.")
+        training_config_dict: dict = {
+            "id_": ID("training_configuration"),  # ID value does not matter but the field is required for validation
+            **json.loads(self.training_configuration_json),
+        }
+        return TrainingConfiguration.model_validate(training_config_dict)
 
 
 @dataclass_json

--- a/interactive_ai/workflows/train/job/utils/train_workflow_data.py
+++ b/interactive_ai/workflows/train/job/utils/train_workflow_data.py
@@ -163,7 +163,10 @@ class TrainWorkflowData:
         :return TrainingConfiguration: Return TrainingConfiguration entity from given training_configuration_json
         """
         if self.training_configuration_json is None:
-            raise ValueError("Training configuration JSON is not set.")
+            raise ValueError(
+                "Training configuration JSON is not set. Please ensure that 'training_configuration_json' is provided "
+                "when initializing TrainWorkflowData, or set it before accessing the 'training_configuration' property."
+            )
         training_config_dict: dict = {
             "id_": ID("training_configuration"),  # ID value does not matter but the field is required for validation
             **json.loads(self.training_configuration_json),

--- a/interactive_ai/workflows/train/job/workflows/train_workflow.py
+++ b/interactive_ai/workflows/train/job/workflows/train_workflow.py
@@ -33,7 +33,7 @@ def train_workflow(  # noqa: PLR0913
     # Training command
     command: list[str] = ["bash", "-c", "run"],
     retain_training_artifacts: bool = False,
-    hyperparameters_json: Optional[str] = None,  # noqa: UP007,
+    training_configuration_json: Optional[str] = None,  # noqa: UP007,
 ) -> None:
     """
     Task node train workflow
@@ -58,7 +58,7 @@ def train_workflow(  # noqa: PLR0913
     :param command: Command to be executed on the primary container, e.g., OTX2 trainer pod.
     :param retain_training_artifacts: If true, do not remove the artifacts in bucket even if training succeeds.
         It would be useful for debugging.
-    :param hyperparameters_json: JSON string containing the hyperparameters to be used for training.
+    :param training_configuration_json: JSON string containing the training configuration, including hyperparameters.
     """
     # Prepare training data, model entities, and bucket directory
     train_data = prepare_training_data_model_and_start_training(
@@ -78,7 +78,7 @@ def train_workflow(  # noqa: PLR0913
         min_annotation_size=min_annotation_size,
         max_number_of_annotations=max_number_of_annotations,
         reshuffle_subsets=reshuffle_subsets,
-        hyperparameters_json=hyperparameters_json,
+        training_configuration_json=training_configuration_json,
     )
 
     evaluate_and_infer(

--- a/interactive_ai/workflows/train/tests/fixtures/configuration.py
+++ b/interactive_ai/workflows/train/tests/fixtures/configuration.py
@@ -3,6 +3,27 @@
 
 import pytest
 from attr import attrs
+from geti_configuration_tools.hyperparameters import (
+    AugmentationParameters,
+    CenterCrop,
+    DatasetPreparationParameters,
+    EarlyStopping,
+    EvaluationParameters,
+    Hyperparameters,
+    TrainingHyperParameters,
+)
+from geti_configuration_tools.training_configuration import (
+    Filtering,
+    GlobalDatasetPreparationParameters,
+    GlobalParameters,
+    MaxAnnotationObjects,
+    MaxAnnotationPixels,
+    MinAnnotationObjects,
+    MinAnnotationPixels,
+    SubsetSplit,
+    TrainingConfiguration,
+)
+from geti_types import ID
 from iai_core.configuration.elements.configurable_parameters import ConfigurableParameters
 from iai_core.configuration.elements.default_model_parameters import DefaultModelParameters
 from iai_core.configuration.elements.hyper_parameters import HyperParameters
@@ -67,4 +88,52 @@ def fxt_hyper_parameters_with_groups(fxt_model_storage, fxt_mongo_id):
         model_storage_id=fxt_model_storage.id_,
         data=DummyHyperParameters(),
         id_=fxt_mongo_id(2),
+    )
+
+
+@pytest.fixture
+def ftx_hyperparameters():
+    yield Hyperparameters(
+        dataset_preparation=DatasetPreparationParameters(
+            augmentation=AugmentationParameters(
+                center_crop=CenterCrop(enable=True, ratio=0.6),
+            )
+        ),
+        training=TrainingHyperParameters(
+            max_epochs=100,
+            early_stopping=EarlyStopping(enable=True, patience=10),
+            learning_rate=0.001,
+        ),
+        evaluation=EvaluationParameters(),
+    )
+
+
+@pytest.fixture
+def fxt_global_parameters():
+    yield GlobalParameters(
+        dataset_preparation=GlobalDatasetPreparationParameters(
+            subset_split=SubsetSplit(
+                training=70,
+                validation=20,
+                test=10,
+                auto_selection=True,
+                remixing=False,
+            ),
+            filtering=Filtering(
+                min_annotation_pixels=MinAnnotationPixels(enable=True, min_annotation_pixels=10),
+                max_annotation_pixels=MaxAnnotationPixels(enable=True, max_annotation_pixels=1000),
+                min_annotation_objects=MinAnnotationObjects(enable=True, min_annotation_objects=5),
+                max_annotation_objects=MaxAnnotationObjects(enable=True, max_annotation_objects=100),
+            ),
+        )
+    )
+
+
+@pytest.fixture
+def fxt_training_configuration(fxt_global_parameters, ftx_hyperparameters):
+    yield TrainingConfiguration(
+        id_=ID("training_config_id"),
+        task_id="task_123",
+        global_parameters=fxt_global_parameters,
+        hyperparameters=ftx_hyperparameters,
     )

--- a/interactive_ai/workflows/train/tests/fixtures/general.py
+++ b/interactive_ai/workflows/train/tests/fixtures/general.py
@@ -40,7 +40,7 @@ def fxt_ote_id(fxt_mongo_id):
 
 
 @pytest.fixture
-def fxt_train_data():
+def fxt_train_data(fxt_training_configuration):
     """
     Get a train data creator with default values
     """
@@ -59,6 +59,7 @@ def fxt_train_data():
         input_model_id: str = "input_model_id",
         compiled_dataset_shards_id: str | None = None,
         reshuffle_subsets: bool = False,
+        training_configuration_json: str = fxt_training_configuration.model_dump_json(),
     ) -> TrainWorkflowData:
         return TrainWorkflowData(
             workspace_id=workspace_id,
@@ -76,6 +77,7 @@ def fxt_train_data():
             min_annotation_size=None,
             max_number_of_annotations=None,
             reshuffle_subsets=reshuffle_subsets,
+            training_configuration_json=training_configuration_json,
         )
 
     yield _build_train_data

--- a/interactive_ai/workflows/train/tests/fixtures/train_workflow_data.py
+++ b/interactive_ai/workflows/train/tests/fixtures/train_workflow_data.py
@@ -57,7 +57,7 @@ def mock_train_data(
     """
     train_data = MagicMock(spec=TrainWorkflowData)
     train_data.get_common_entities.return_value = (fxt_project, fxt_detection_node)
-    train_data.get_hyper_parameters.return_value = fxt_configuration_1
+    train_data.get_legacy_hyper_parameters.return_value = fxt_configuration_1
     train_data.get_compiled_dataset_shards.return_value = fxt_norm_compiled_dataset_shards
     train_data.hyperparameters_id = "dummy_id"
     return train_data

--- a/interactive_ai/workflows/train/tests/unit/commands/test_create_train_dataset_command.py
+++ b/interactive_ai/workflows/train/tests/unit/commands/test_create_train_dataset_command.py
@@ -18,7 +18,7 @@ def raise_exception(*args, **kwargs):
 
 class TestCreateDatasetCommand:
     def test_create_train_dataset_command(
-        self, fxt_project, fxt_dataset_storage, fxt_detection_node, fxt_dataset
+        self, fxt_project, fxt_dataset_storage, fxt_detection_node, fxt_dataset, fxt_training_configuration
     ) -> None:
         # Arrange
         mock_pipeline_dataset = MagicMock()
@@ -44,6 +44,7 @@ class TestCreateDatasetCommand:
                 task_node=fxt_detection_node,
                 max_training_dataset_size=100,
                 reshuffle_subsets=False,
+                training_configuration=fxt_training_configuration,
             )
             command.execute()
 
@@ -56,10 +57,11 @@ class TestCreateDatasetCommand:
                 task_node=fxt_detection_node,
                 max_training_dataset_size=100,
                 reshuffle_subsets=False,
+                training_configuration=fxt_training_configuration,
             )
 
     def test_create_train_dataset_command_error(
-        self, fxt_project, fxt_dataset_storage, fxt_detection_node, fxt_dataset
+        self, fxt_project, fxt_dataset_storage, fxt_detection_node, fxt_dataset, fxt_training_configuration
     ) -> None:
         # Arrange
         mock_pipeline_dataset = MagicMock()
@@ -86,6 +88,7 @@ class TestCreateDatasetCommand:
                 task_node=fxt_detection_node,
                 max_training_dataset_size=100,
                 reshuffle_subsets=False,
+                training_configuration=fxt_training_configuration,
             )
             with pytest.raises(DatasetCreationFailedException):
                 command.execute()

--- a/interactive_ai/workflows/train/tests/unit/tasks/prepare_and_train/test_create_task_train_dataset_task.py
+++ b/interactive_ai/workflows/train/tests/unit/tasks/prepare_and_train/test_create_task_train_dataset_task.py
@@ -65,6 +65,7 @@ class TestCreateTrainDataset:
             task_node=task_node,
             max_training_dataset_size=100,
             reshuffle_subsets=False,
+            training_configuration=train_data.training_configuration,
         )
         patched_command.execute.assert_called_once_with()
 

--- a/interactive_ai/workflows/train/tests/unit/tasks/prepare_and_train/test_get_train_data.py
+++ b/interactive_ai/workflows/train/tests/unit/tasks/prepare_and_train/test_get_train_data.py
@@ -55,6 +55,7 @@ class TestGetTrainDataTask:
         fxt_project,
         fxt_train_data,
         obsolete_model,
+        fxt_training_configuration,
     ) -> None:
         # Arrange
         mocked_get_project.return_value = fxt_project
@@ -91,6 +92,7 @@ class TestGetTrainDataTask:
             infer_on_pipeline=infer_on_pipeline,
             model_storage_id=self.model_storage_id,
             hyper_parameters_id=self.hyperparameters_id,
+            training_configuration_json=fxt_training_configuration.model_dump_json(),
         )
 
         # Assert

--- a/interactive_ai/workflows/train/tests/unit/tasks/prepare_and_train/test_prepare_data_and_train.py
+++ b/interactive_ai/workflows/train/tests/unit/tasks/prepare_and_train/test_prepare_data_and_train.py
@@ -86,7 +86,7 @@ class TestPrepareTrainingDataTask:
         # Arrange
         train_data = fxt_train_data(workspace_id=WORKSPACE_ID, project_id=PROJECT_ID, task_id=TASK_ID)
         train_data.get_compiled_dataset_shards = MagicMock()
-        hyperparameters = {"learning_rate": 0.01, "batch_size": 32}
+        training_configuration = {"hyperparameters": {"learning_rate": 0.01, "batch_size": 32}}
 
         mocked_get_train_data.return_value = train_data
         dataset = Dataset(ID(DATASET_ID))
@@ -96,7 +96,7 @@ class TestPrepareTrainingDataTask:
         mocked_train_task = MagicMock()
         mocked_create_flyte_container_task.return_value = mocked_train_task
         mocked_asyncio_run.return_value = ({"requests": {}, "limits": {}}, "cpu")
-        hyperparameters_json = json.dumps(hyperparameters)
+        training_configuration_json = json.dumps(training_configuration)
 
         # Act
         prepare_training_data_model_and_start_training(
@@ -114,7 +114,7 @@ class TestPrepareTrainingDataTask:
             max_training_dataset_size=100,
             command=["bash", "-c", "run"],
             reshuffle_subsets=reshuffle_subsets,
-            hyperparameters_json=hyperparameters_json,
+            training_configuration_json=training_configuration_json,
         )
 
         # Assert
@@ -130,7 +130,7 @@ class TestPrepareTrainingDataTask:
             max_number_of_annotations=None,
             min_annotation_size=None,
             reshuffle_subsets=reshuffle_subsets,
-            hyperparameters_json=hyperparameters_json,
+            training_configuration_json=training_configuration_json,
         )
         mocked_create_task_train_dataset.assert_called_once_with(train_data=train_data, max_training_dataset_size=100)
 

--- a/interactive_ai/workflows/train/tests/unit/tasks/prepare_and_train/test_train_helpers.py
+++ b/interactive_ai/workflows/train/tests/unit/tasks/prepare_and_train/test_train_helpers.py
@@ -37,7 +37,7 @@ class TestTrainHelpers:
         monkeypatch.setenv(FeatureFlag.FEATURE_FLAG_FP16_INFERENCE.name, str(feature_flag_setting).lower())
         mock_model_repo.generate_id.side_effect = [ID(str(i)) for i in range(5)]
         dummy_config = {"dummy_key": "dummy_value"}
-        mock_train_data.hyperparameters_json = json.dumps(dummy_config)
+        mock_train_data.training_configuration_json = json.dumps(dummy_config)
         mock_model_manifest = MagicMock()
         mock_model_manifest.capabilities = Capabilities(xai=has_xai)
 

--- a/interactive_ai/workflows/train/tests/unit/workflows/test_train_workflow.py
+++ b/interactive_ai/workflows/train/tests/unit/workflows/test_train_workflow.py
@@ -112,7 +112,7 @@ class TestTrainWorkflow:
                 min_annotation_size=None,
                 max_number_of_annotations=None,
                 reshuffle_subsets=reshuffle_subsets,
-                hyperparameters_json=None,
+                training_configuration_json=None,
             )
             mocked_evaluate_and_infer.assert_called_once_with(
                 train_data=data_task_trainer,

--- a/libs/configuration_tools/src/geti_configuration_tools/training_configuration.py
+++ b/libs/configuration_tools/src/geti_configuration_tools/training_configuration.py
@@ -26,7 +26,7 @@ class SubsetSplit(BaseModel):
         ge=1, le=100, default=10, title="Test percentage", description="Percentage of data to use for testing"
     )
     auto_selection: bool = Field(
-        default=True, title="Auto selection", description="Whether to automatically select data for each subset"
+        default=False, title="Auto selection", description="Whether to automatically select data for each subset"
     )
     remixing: bool = Field(default=False, title="Remixing", description="Whether to remix data between subsets")
     dataset_size: int | None = Field(


### PR DESCRIPTION
## 📝 Description

[release 2.12 branch]

Replace the old legacy configuration with training_configuration for training subset splits.
Note: For the subset distribution settings to take effect, training from scratch with dataset reshuffle is required if there are existing models.

<!--  
Provide a clear summary of the changes and the context behind them. Describe **what** was changed, **why** it was needed, and **how** the changes address the issue or add value.

If the PR addresses a specific GitHub issue, link it through the 'Development' panel on the side.
This will ensure that the issue is automatically closed after the PR is merged.
Alternatively, include one of the special GitHub keywords in the description, for example:
- Fixes #<issue_number>
- Closes #<issue_number>
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [x] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [x] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [x] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
