### PR TITLE
Fix ensuring that About page links are be clickable only on the text

### DIFF
--- a/web_ui/src/pages/about-page/about-page.module.scss
+++ b/web_ui/src/pages/about-page/about-page.module.scss
@@ -20,6 +20,7 @@
 
 .link {
     color: var(--energy-blue) !important;
+    width: fit-content;
 }
 
 .licenceButton {


### PR DESCRIPTION
## 📝 Description

Fix ensuring that About page links are be clickable only on the text


https://github.com/user-attachments/assets/0429b6ca-7e83-4c6d-b836-766a8ad9de27



## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [x] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
