### PR TITLE
Fix issue with bounding boxes not being properly displayed on Firefox.

### DIFF
--- a/web_ui/src/pages/annotator/annotation/layers/layer.component.tsx
+++ b/web_ui/src/pages/annotator/annotation/layers/layer.component.tsx
@@ -64,7 +64,7 @@ export const Layer = ({
                                     annotation={annotation}
                                     selectedTask={selectedTask}
                                     isPredictionMode={isPredictionMode}
-                                    maskId={`url(#${maskId})`}
+                                    maskId={isNonEmptyArray(savedMasks) ? `url(#${maskId})` : undefined}
                                 />
                             </svg>
                         )}


### PR DESCRIPTION
## 📝 Description

There was an issue on FireFox what some of the bounding boxes were cut or even displayed as invisible.
<img width="841" height="700" alt="Screenshot 2025-08-06 at 16 42 24" src="https://github.com/user-attachments/assets/b010bbbe-130d-41bf-af48-a016201e8cc0" />
Turned out it was an issue with masks. Where there were no masks with the ID Chrome simply ignored it. Firefox is stricter about SVG standards and that's why this unexpected behaviour occured.
Now if there are no masks the id will be undefined which is perfectly fine for the g element. If maskId is undefined, the SVG <g> will not be masked. The annotation will display as usual, with no masking applied. No error will occur; it simply means no mask is used.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [x] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
