### PR TITLE
:chore: Remove jest dependency from packages

### DIFF
--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -24176,16 +24176,13 @@
         "@geti/config": "*",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
-        "@types/jest": "^29.5.14",
         "@types/node": "^22.15.3",
         "eslint": "^9.31.0",
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-jest": "^28.11.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
-        "jest": "^29.7.0",
         "typescript": "^5.8.3"
       }
     },
@@ -24265,16 +24262,13 @@
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
-        "@types/jest": "^29.5.14",
         "eslint": "^9.25.1",
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-jest": "^28.11.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-playwright": "^2.2.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
-        "jest": "^29.7.0",
         "typescript": "^5.8.3"
       }
     }

--- a/web_ui/packages/core/package.json
+++ b/web_ui/packages/core/package.json
@@ -20,7 +20,7 @@
   },
   "type": "module",
   "scripts": {
-    "test:unit": "npm run test:unit:ui --workspace=root --config jest.config.js --watchAll=false",
+    "test:unit": "npm run test:unit --workspace=root --config jest.config.js --watchAll=false",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts*\" --max-warnings 0",
     "lint:fix": "eslint --fix \"./src/**/*.ts*\""

--- a/web_ui/packages/core/package.json
+++ b/web_ui/packages/core/package.json
@@ -9,21 +9,18 @@
     "@geti/config": "*",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@types/jest": "^29.5.14",
     "@types/node": "^22.15.3",
     "eslint": "^9.31.0",
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "jest": "^29.7.0",
     "typescript": "^5.8.3"
   },
   "type": "module",
   "scripts": {
-    "test:unit": "jest --config jest.config.js --watchAll=false",
+    "test:unit": "npx jest --config jest.config.js --watchAll=false",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts*\" --max-warnings 0",
     "lint:fix": "eslint --fix \"./src/**/*.ts*\""

--- a/web_ui/packages/core/package.json
+++ b/web_ui/packages/core/package.json
@@ -20,7 +20,7 @@
   },
   "type": "module",
   "scripts": {
-    "test:unit": "npx jest --config jest.config.js --watchAll=false",
+    "test:unit": "npm run test:unit:ui --workspace=root --config jest.config.js --watchAll=false",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts*\" --max-warnings 0",
     "lint:fix": "eslint --fix \"./src/**/*.ts*\""

--- a/web_ui/packages/ui/package.json
+++ b/web_ui/packages/ui/package.json
@@ -16,20 +16,17 @@
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@types/jest": "^29.5.14",
     "eslint": "^9.25.1",
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.11.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-playwright": "^2.2.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "jest": "^29.7.0",
     "typescript": "^5.8.3"
   },
   "scripts": {
-    "test:unit": "jest --config jest.config.js --watchAll=false",
+    "test:unit": "npx jest --config jest.config.js --watchAll=false",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts*\" --max-warnings 0",
     "lint:fix": "eslint --fix \"./src/**/*.ts*\""

--- a/web_ui/packages/ui/package.json
+++ b/web_ui/packages/ui/package.json
@@ -26,7 +26,7 @@
     "typescript": "^5.8.3"
   },
   "scripts": {
-    "test:unit": "npm run test:unit:ui --workspace=root --config jest.config.js --watchAll=false",
+    "test:unit": "npm run test:unit --workspace=root --config jest.config.js --watchAll=false",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts*\" --max-warnings 0",
     "lint:fix": "eslint --fix \"./src/**/*.ts*\""

--- a/web_ui/packages/ui/package.json
+++ b/web_ui/packages/ui/package.json
@@ -26,7 +26,7 @@
     "typescript": "^5.8.3"
   },
   "scripts": {
-    "test:unit": "npx jest --config jest.config.js --watchAll=false",
+    "test:unit": "npm run test:unit:ui --workspace=root --config jest.config.js --watchAll=false",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts*\" --max-warnings 0",
     "lint:fix": "eslint --fix \"./src/**/*.ts*\""


### PR DESCRIPTION
## 📝 Description

This PR removes `jest` dependency from our packages, relying only on the main app. They do not (At least for now) work standalone so this change removes duplication and it doesnt inject `jest` into our other apps (e.g. Tune) which also conflicts since we're using Vitest over there. I think we can get rid of even more but let's take it slow.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
