### PR TITLE
Relax constraints for subset split [release 2.12]

### DIFF
--- a/libs/configuration_tools/src/geti_configuration_tools/training_configuration.py
+++ b/libs/configuration_tools/src/geti_configuration_tools/training_configuration.py
@@ -43,7 +43,7 @@ class SubsetSplit(BaseModel):
             raise ValueError("Sum of subsets should be equal to 100")
         # check that all subsets can have at least one item
         if self.dataset_size is not None and self.dataset_size < 3:
-            raise ValueError("Each subset must be at least contain one item")
+            raise ValueError("The dataset is too small to assign at least one item to each subset")
         return self
 
 

--- a/libs/configuration_tools/src/geti_configuration_tools/training_configuration.py
+++ b/libs/configuration_tools/src/geti_configuration_tools/training_configuration.py
@@ -1,6 +1,5 @@
 # Copyright (C) 2022-2025 Intel Corporation
 # LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
-import math
 from typing import Any
 
 from geti_types import ID, PersistentEntity
@@ -42,13 +41,9 @@ class SubsetSplit(BaseModel):
     def validate_subsets(self) -> "SubsetSplit":
         if (self.training + self.validation + self.test) != 100:
             raise ValueError("Sum of subsets should be equal to 100")
-        # check that all subsets have at least one item if dataset_size is provided
-        if self.dataset_size is not None:
-            validation_size = math.floor(self.dataset_size * self.validation / 100)
-            test_size = math.floor(self.dataset_size * self.test / 100)
-            train_size = self.dataset_size - validation_size - test_size
-            if train_size < 1 or validation_size < 1 or test_size < 1:
-                raise ValueError("Each subset must be at least contain one item")
+        # check that all subsets can have at least one item
+        if self.dataset_size is not None and self.dataset_size < 3:
+            raise ValueError("Each subset must be at least contain one item")
         return self
 
 

--- a/libs/configuration_tools/tests/test_training_configuration.py
+++ b/libs/configuration_tools/tests/test_training_configuration.py
@@ -254,7 +254,7 @@ class TestTrainingConfiguration:
                             "training": 50,
                             "validation": 49,
                             "test": 1,
-                            "dataset_size": 10,
+                            "dataset_size": 2,
                         }
                     }
                 }


### PR DESCRIPTION
## 📝 Description

Allow to train with only 3 annotations. The subset distribution do not matter in this case, as the subset split algorithm will always assign at least one annotation to each subset.

Related but does not fix issue: https://github.com/open-edge-platform/geti/issues/1063

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
