### PR TITLE
Retain previous annotation until mouse release

### DIFF
--- a/web_ui/src/pages/annotator/providers/annotator-provider/annotator-provider.test.tsx
+++ b/web_ui/src/pages/annotator/providers/annotator-provider/annotator-provider.test.tsx
@@ -111,7 +111,9 @@ describe('Annotator provider', (): void => {
             return (
                 <div>
                     <ul aria-label='annotations'>
-                        {scene.annotations?.map((annotation) => <li key={annotation.id}>{annotation.id}</li>)}
+                        {scene.annotations?.map((annotation) => (
+                            <li key={annotation.id}>{annotation.id}</li>
+                        ))}
                     </ul>
                 </div>
             );

--- a/web_ui/src/pages/annotator/providers/annotator-provider/annotator-provider.test.tsx
+++ b/web_ui/src/pages/annotator/providers/annotator-provider/annotator-provider.test.tsx
@@ -111,9 +111,7 @@ describe('Annotator provider', (): void => {
             return (
                 <div>
                     <ul aria-label='annotations'>
-                        {scene.annotations?.map((annotation) => (
-                            <li key={annotation.id}>{annotation.id}</li>
-                        ))}
+                        {scene.annotations?.map((annotation) => <li key={annotation.id}>{annotation.id}</li>)}
                     </ul>
                 </div>
             );

--- a/web_ui/src/pages/annotator/tools/keypoint-tool/keypoint-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/keypoint-tool/keypoint-tool.component.tsx
@@ -58,11 +58,9 @@ export const KeypointTool = ({ annotationToolContext }: ToolAnnotationContextPro
         // We add a label so that the annotation doesn't get flagged as invalid by `hasInvalidAnnotations`
         // when the user submits it
         const newAnnotation = { ...keypointAnnotation, isSelected: true, labels: [labelFromUser(templateLabels[0])] };
-
-        if (isEmpty(visibleAnnotations)) {
-            annotationToolContext.scene.addAnnotations([newAnnotation]);
-            setCurrentBoundingBox(null);
-        }
+        annotationToolContext.scene.replaceAnnotations([
+            { ...newAnnotation, labels: [labelFromUser(templateLabels[0])], isSelected: true },
+        ]);
     };
 
     const handleRemoveOldABoundingBox = () => {

--- a/web_ui/src/pages/annotator/tools/keypoint-tool/keypoint-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/keypoint-tool/keypoint-tool.component.tsx
@@ -56,9 +56,7 @@ export const KeypointTool = ({ annotationToolContext }: ToolAnnotationContextPro
         // We add a label so that the annotation doesn't get flagged as invalid by `hasInvalidAnnotations`
         // when the user submits it
         const newAnnotation = { ...keypointAnnotation, isSelected: true, labels: [labelFromUser(templateLabels[0])] };
-        annotationToolContext.scene.replaceAnnotations([
-            { ...newAnnotation, labels: [labelFromUser(templateLabels[0])], isSelected: true },
-        ]);
+        annotationToolContext.scene.replaceAnnotations([newAnnotation]);
     };
 
     const handleRemoveOldABoundingBox = () => {

--- a/web_ui/src/pages/annotator/tools/keypoint-tool/keypoint-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/keypoint-tool/keypoint-tool.component.tsx
@@ -8,7 +8,6 @@ import { Point } from '../../../../core/annotations/shapes.interface';
 import { labelFromUser } from '../../../../core/annotations/utils';
 import { PoseEdges } from '../../annotation/shapes/pose-edges.component';
 import { PoseKeypoints } from '../../annotation/shapes/pose-keypoints.component';
-import { useVisibleAnnotations } from '../../hooks/use-visible-annotations.hook';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { useZoom } from '../../zoom/zoom-provider.component';
 import { ResizeAnchor } from '../edit-tool/resize-anchor.component';
@@ -29,7 +28,6 @@ import {
 export const KeypointTool = ({ annotationToolContext }: ToolAnnotationContextProps): JSX.Element => {
     const { zoomState } = useZoom();
     const { image, roi } = useROI();
-    const visibleAnnotations = useVisibleAnnotations();
     const { templateLabels, templatePoints, currentBoundingBox, setCurrentBoundingBox, setCursorDirection } =
         useKeypointState();
 

--- a/web_ui/src/pages/annotator/tools/keypoint-tool/secondary-toolbar.component.tsx
+++ b/web_ui/src/pages/annotator/tools/keypoint-tool/secondary-toolbar.component.tsx
@@ -101,27 +101,6 @@ export const SecondaryToolbar = ({ annotationToolContext }: ToolAnnotationContex
                 </ActionButton>
                 <Tooltip>Mirror Y axis</Tooltip>
             </TooltipTrigger>
-
-            {hasCurrentBoundingBox && (
-                <>
-                    <TooltipTrigger placement={'bottom'}>
-                        <ActionButton
-                            isQuiet
-                            aria-label={'reject keypoint annotation'}
-                            onPress={handleRejectAnnotation}
-                            marginEnd={'size-100'}
-                        >
-                            <Reject height={20} width={20} />
-                        </ActionButton>
-                        <Tooltip>{`Reject keypoint annotation`}</Tooltip>
-                    </TooltipTrigger>
-
-                    <TooltipTrigger placement={'bottom'}>
-                        <AcceptButton aria-label={'accept new keypoint annotation'} onPress={handleAcceptAnnotation} />
-                        <Tooltip>{'Accept new annotation'}</Tooltip>
-                    </TooltipTrigger>
-                </>
-            )}
         </Flex>
     );
 };

--- a/web_ui/src/pages/annotator/tools/keypoint-tool/secondary-toolbar.component.tsx
+++ b/web_ui/src/pages/annotator/tools/keypoint-tool/secondary-toolbar.component.tsx
@@ -2,48 +2,26 @@
 // LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 
 import { ActionButton, Divider, Flex, Text, Tooltip, TooltipTrigger } from '@geti/ui';
-import { Delete, LineMappingLight, Reject } from '@geti/ui/icons';
+import { Delete, LineMappingLight } from '@geti/ui/icons';
 
 import { isKeypointAnnotation } from '../../../../core/annotations/services/utils';
-import { labelFromUser } from '../../../../core/annotations/utils';
-import { AcceptButton } from '../../../../shared/components/quiet-button/accept-button.component';
 import { PointAxis } from '../../../utils';
 import { useVisibleAnnotations } from '../../hooks/use-visible-annotations.hook';
-import { useZoom } from '../../zoom/zoom-provider.component';
 import { ToolAnnotationContextProps } from '../tools.interface';
 import { useKeypointState } from './keypoint-state-provider.component';
-import { getAnnotationInBoundingBox, getInnerPaddedBoundingBox, mirrorPointsAcrossAxis } from './utils';
+import { mirrorPointsAcrossAxis } from './utils';
 
 export const SecondaryToolbar = ({ annotationToolContext }: ToolAnnotationContextProps) => {
-    const { zoomState } = useZoom();
     const visibleAnnotations = useVisibleAnnotations();
 
     const { scene } = annotationToolContext;
     const keypointAnnotation = visibleAnnotations.find(isKeypointAnnotation);
-    const { templateLabels, templatePoints, currentBoundingBox, setCurrentBoundingBox } = useKeypointState();
+    const { currentBoundingBox, setCurrentBoundingBox } = useKeypointState();
     const hasAnnotations = keypointAnnotation !== undefined;
     const hasCurrentBoundingBox = currentBoundingBox !== null;
 
-    const handleAcceptAnnotation = () => {
-        if (currentBoundingBox === null) {
-            return;
-        }
-
-        setCurrentBoundingBox(null);
-        const annotation = getAnnotationInBoundingBox(
-            templatePoints,
-            getInnerPaddedBoundingBox(currentBoundingBox, zoomState.zoom)
-        );
-
-        scene.replaceAnnotations([{ ...annotation, labels: [labelFromUser(templateLabels[0])], isSelected: true }]);
-    };
-
-    const handleRejectAnnotation = () => {
-        setCurrentBoundingBox(null);
-        keypointAnnotation && scene.replaceAnnotations([{ ...keypointAnnotation, isSelected: true }], true);
-    };
-
     const handleDeleteAnnotation = () => {
+        setCurrentBoundingBox(null);
         scene.removeAnnotations(visibleAnnotations);
     };
 
@@ -69,7 +47,7 @@ export const SecondaryToolbar = ({ annotationToolContext }: ToolAnnotationContex
             <TooltipTrigger placement={'bottom'}>
                 <ActionButton
                     isQuiet
-                    isDisabled={!hasAnnotations || hasCurrentBoundingBox}
+                    isDisabled={!hasAnnotations}
                     onPress={handleDeleteAnnotation}
                     aria-label={'delete keypoint annotation'}
                 >

--- a/web_ui/src/pages/annotator/tools/keypoint-tool/secondary-toolbar.test.tsx
+++ b/web_ui/src/pages/annotator/tools/keypoint-tool/secondary-toolbar.test.tsx
@@ -1,13 +1,12 @@
 // Copyright (C) 2022-2025 Intel Corporation
 // LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import { Annotation } from '../../../../core/annotations/annotation.interface';
 import { ShapeType } from '../../../../core/annotations/shapetype.enum';
 import { fakeAnnotationToolContext } from '../../../../test-utils/fake-annotator-context';
 import { getMockedAnnotation } from '../../../../test-utils/mocked-items-factory/mocked-annotations';
-import { getMockedLabel } from '../../../../test-utils/mocked-items-factory/mocked-labels';
 import { AnnotationToolContext } from '../../core/annotation-tool-context.interface';
 import { useVisibleAnnotations } from '../../hooks/use-visible-annotations.hook';
 import { annotatorRender } from '../../test-utils/annotator-render';

--- a/web_ui/src/pages/annotator/tools/keypoint-tool/secondary-toolbar.test.tsx
+++ b/web_ui/src/pages/annotator/tools/keypoint-tool/secondary-toolbar.test.tsx
@@ -78,30 +78,4 @@ describe('KeypointTool', () => {
         expect(screen.getByRole('button', { name: 'mirror X-axis' })).toBeEnabled();
         expect(screen.getByRole('button', { name: 'mirror Y-axis' })).toBeEnabled();
     });
-
-    it('accepts keypoint annotation with a label so it does not get flagged as invalid', async () => {
-        const mockedLabel = getMockedLabel({ id: 'test-label' });
-        const annotationToolContext = fakeAnnotationToolContext();
-
-        await renderApp({
-            annotationToolContext,
-            annotations: [getMockedAnnotation({}, ShapeType.Pose)],
-            keypointState: {
-                templateLabels: [mockedLabel],
-                currentBoundingBox: { x: 0, y: 0, width: 10, height: 10 },
-            },
-        });
-
-        fireEvent.click(screen.getByRole('button', { name: /accept new keypoint annotation/i }));
-
-        expect(annotationToolContext.scene.replaceAnnotations).toHaveBeenCalledWith([
-            expect.objectContaining({
-                labels: expect.arrayContaining([
-                    expect.objectContaining({
-                        id: mockedLabel.id,
-                    }),
-                ]),
-            }),
-        ]);
-    });
 });

--- a/web_ui/tests/features/annotator/keypoint-detection/keypoint-detection.spec.ts
+++ b/web_ui/tests/features/annotator/keypoint-detection/keypoint-detection.spec.ts
@@ -84,7 +84,7 @@ test.describe(`keypoint detection`, () => {
         await assertPredictionVisibility(page, labels.rightBackLeg.name, 16);
     });
 
-    test('adjust template orientation based on mouse movement', async ({ page, templateManagerPage }) => {
+    test.only('adjust template orientation based on mouse movement', async ({ page, templateManagerPage }) => {
         await page.goto(annotatorUrl);
 
         await page.getByLabel('Keypoint tool').click();
@@ -103,7 +103,6 @@ test.describe(`keypoint detection`, () => {
 
         await page.mouse.move(300, 300, { steps: 20 });
         await page.mouse.up({ button: 'left' });
-        await page.getByLabel('accept new keypoint annotation').click();
 
         const updatedHeadPosition = await templateManagerPage.getPosition(
             page.getByLabel(`Resize keypoint ${labels.head.name} anchor`)

--- a/web_ui/tests/features/annotator/keypoint-detection/keypoint-detection.spec.ts
+++ b/web_ui/tests/features/annotator/keypoint-detection/keypoint-detection.spec.ts
@@ -84,7 +84,7 @@ test.describe(`keypoint detection`, () => {
         await assertPredictionVisibility(page, labels.rightBackLeg.name, 16);
     });
 
-    test.only('adjust template orientation based on mouse movement', async ({ page, templateManagerPage }) => {
+    test('adjust template orientation based on mouse movement', async ({ page, templateManagerPage }) => {
         await page.goto(annotatorUrl);
 
         await page.getByLabel('Keypoint tool').click();
@@ -187,5 +187,23 @@ test.describe(`keypoint detection`, () => {
         expect(await page.getByRole('listitem').count()).toBe(7);
         await page.keyboard.press('Delete');
         expect(await page.getByRole('listitem').count()).toBe(0);
+    });
+
+    test('Retain previous annotation until mouse release on the next one', async ({ page, templateManagerPage }) => {
+        await page.goto(annotatorUrl);
+        await page.getByLabel('Keypoint tool').click();
+
+        const firstHeadPosition = await templateManagerPage.getPosition(page.getByLabel(`label ${labels.head.name}`));
+
+        // Draw second annotation
+        await page.mouse.move(600, 500);
+        await page.mouse.down({ button: 'left' });
+        await page.mouse.move(900, 800, { steps: 20 });
+        await page.mouse.up();
+
+        // If annotations are replaced, the position should change
+        const newHeadPosition = await templateManagerPage.getPosition(page.getByLabel(`label ${labels.head.name}`));
+
+        expect(newHeadPosition).not.toEqual(firstHeadPosition);
     });
 });


### PR DESCRIPTION
## 📝 Description

Before:
The previous annotation will remain visible until the user explicitly accepts the new one with accept button.

After:
The previous annotation will remain visible until the user releases the mouse after drawing the new one. The accept/reject buttons were be removed as no longer necessary.

https://github.com/user-attachments/assets/e1ba4b7b-561e-4369-bf15-aff158eaafa4



## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [x] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
