### PR TITLE
fix: Export dialog is interactive

### DIFF
--- a/web_ui/src/pages/project-details/components/project-dataset/dataset-tab-list.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-dataset/dataset-tab-list.component.tsx
@@ -10,6 +10,8 @@ import { CollapsedItemsPicker } from '../../../../shared/components/collapsed-it
 import { TabItem } from '../../../../shared/components/tabs/tabs.interface';
 import { hasEqualId } from '../../../../shared/utils';
 import { useProject } from '../../providers/project-provider/project-provider.component';
+import { ExportDatasetDialog } from './export-dataset/export-dataset-dialog.component';
+import { useExportImportDatasetDialogStates } from './export-dataset/export-import-dataset-dialog-provider.component';
 import { ProjectDatasetTabActions } from './project-dataset-tab-actions.component';
 import { useSelectedDataset } from './use-selected-dataset/use-selected-dataset.hook';
 import { MAX_NUMBER_OF_DISPLAYED_DATASETS } from './utils';
@@ -23,6 +25,8 @@ export const DatasetTabList = () => {
     const numberOfDatasets = project.datasets.length;
 
     const { createDataset, pinnedDatasets, collapsedDatasets, handleCreateDataset, handleSelectDataset } = useDataset();
+
+    const { exportDialogState } = useExportImportDatasetDialogStates();
 
     const hasSelectedPinnedDataset = pinnedDatasets.find(hasEqualId(selectedDataset.id)) !== undefined;
     const collapsedPickerItems = collapsedDatasets.map(({ id, name }) => ({ id, name }));
@@ -42,6 +46,8 @@ export const DatasetTabList = () => {
                     </Item>
                 )}
             </TabList>
+
+            <ExportDatasetDialog triggerState={exportDialogState} datasetName={selectedDataset.name} />
 
             {numberOfDatasets > MAX_NUMBER_OF_DISPLAYED_DATASETS ? (
                 <CollapsedItemsPicker

--- a/web_ui/src/pages/project-details/components/project-dataset/project-dataset-tab-actions.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-dataset/project-dataset-tab-actions.component.tsx
@@ -19,7 +19,6 @@ import { DeleteDialog } from '../../../../shared/components/delete-dialog/delete
 import { EditNameDialog } from '../../../../shared/components/edit-name-dialog/edit-name-dialog.component';
 import { useMedia } from '../../../media/providers/media-provider.component';
 import { useProject } from '../../providers/project-provider/project-provider.component';
-import { ExportDatasetDialog } from './export-dataset/export-dataset-dialog.component';
 import { useExportImportDatasetDialogStates } from './export-dataset/export-import-dataset-dialog-provider.component';
 import { useSelectedDataset } from './use-selected-dataset/use-selected-dataset.hook';
 import { DatasetTabActions, getDatasetTabActions } from './utils';
@@ -39,7 +38,7 @@ export const ProjectDatasetTabActions = ({ dataset }: ProjectDatasetTabActionsPr
     const updateDatasetDialogState = useOverlayTriggerState({});
     const { datasetImportDialogState: datasetImportDialogTrigger, exportDialogState } =
         useExportImportDatasetDialogStates();
-    const { id: selectedDatasetId, name: selectedDatasetName } = useSelectedDataset();
+    const { id: selectedDatasetId } = useSelectedDataset();
 
     const hasMedia = !isEmpty(media);
     const datasetNames = project.datasets.map(({ name }) => name);
@@ -109,7 +108,6 @@ export const ProjectDatasetTabActions = ({ dataset }: ProjectDatasetTabActionsPr
                 names={datasetNames}
                 title={'dataset name'}
             />
-            <ExportDatasetDialog triggerState={exportDialogState} datasetName={selectedDatasetName} />
         </Flex>
     );
 };

--- a/web_ui/src/pages/project-details/components/project-dataset/project-dataset-tab-actions.test.tsx
+++ b/web_ui/src/pages/project-details/components/project-dataset/project-dataset-tab-actions.test.tsx
@@ -161,17 +161,21 @@ describe('ProjectDatasetTabActions', () => {
     });
 
     it('should show export dataset dialog', async () => {
+        const mockOpen = jest.fn();
         await renderApp({
             exportDialogState: {
                 isOpen: true,
                 setOpen: jest.fn(),
-                open: jest.fn(),
+                open: mockOpen,
                 close: jest.fn(),
                 toggle: jest.fn(),
             },
         });
 
-        expect(screen.getByText('Select dataset export format')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('button', { name: 'open dataset menu' }));
+        fireEvent.click(screen.getByRole('menuitem', { name: DatasetTabActions.ExportDataset }));
+
+        expect(mockOpen).toHaveBeenCalled();
     });
 
     describe('Menu actions', () => {

--- a/web_ui/tests/features/project-dataset/export-dataset.spec.ts
+++ b/web_ui/tests/features/project-dataset/export-dataset.spec.ts
@@ -6,7 +6,7 @@ import { expect, Page } from '@playwright/test';
 import { JobState, JobStepState, JobType } from '../../../src/core/jobs/jobs.const';
 import { test } from '../../fixtures/base-test';
 import { switchCallsAfter } from '../../utils/api';
-import { getMockedJob, projects } from './mocks';
+import { getMockedJob, projects, projectWithTwoDatasets } from './mocks';
 
 const [project] = projects.projects;
 
@@ -79,6 +79,7 @@ test.describe('export dataset', () => {
         registerApiResponse('TriggerDatasetExport', async (_, res, ctx) =>
             res(ctx.json({ export_dataset_id: exportId, status_url: `url/test`, job_id: exportId }))
         );
+        registerApiResponse('GetProjectInfo', (_, res, ctx) => res(ctx.json(projectWithTwoDatasets)));
 
         registerApiResponse(
             'GetJob',


### PR DESCRIPTION
## 📝 Description

The issue was that export dialog was not interactive in cases when we had more than one dataset (e.g. dataset + testing set). It was because more than one export dialog was displayed. This PR fixes it.

<!--  
Provide a clear summary of the changes and the context behind them. Describe **what** was changed, **why** it was needed, and **how** the changes address the issue or add value.

If the PR addresses a specific GitHub issue, link it through the 'Development' panel on the side.
This will ensure that the issue is automatically closed after the PR is merged.
Alternatively, include one of the special GitHub keywords in the description, for example:
- Fixes #<issue_number>
- Closes #<issue_number>
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🐞 **Bug fix** – Non-breaking change which fixes an issue

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [X] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and meaningful
- [X] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ✅ I have added tests that prove my fix is effective or my feature works
