### PR TITLE
refactor: Set colors for toast icons explicitly

### DIFF
--- a/web_ui/packages/ui/src/toast/toast.component.tsx
+++ b/web_ui/packages/ui/src/toast/toast.component.tsx
@@ -38,10 +38,10 @@ type CustomToastProps = {
 };
 
 const ICON: Record<ToastType, ReactNode> = {
-    success: <AcceptCircle />,
-    error: <CrossCircle />,
-    warning: <Alert />,
-    info: <Info />,
+    success: <AcceptCircle className={classes.icon} />,
+    error: <CrossCircle className={classes.icon} />,
+    warning: <Alert className={classes.icon} />,
+    info: <Info className={classes.icon} />,
     neutral: null,
 };
 
@@ -53,7 +53,7 @@ const ToastCloseButton = ({ id }: { id: string }) => {
             aria-label={'Close toast'}
             UNSAFE_className={classes.closeButton}
         >
-            <CloseSmall className={classes.closeIcon} />
+            <CloseSmall className={classes.icon} />
         </ActionButton>
     );
 };
@@ -95,7 +95,7 @@ const CustomToast = ({ message, id, actionButtons, type, hasCloseButton = true, 
                 >
                     <Flex flex={1} alignItems={'center'} justifyContent={'space-between'}>
                         <Flex gap={'size-100'} alignItems={'center'}>
-                            <View>{icon}</View>
+                            <Flex>{icon}</Flex>
                             <Text>{message}</Text>
                         </Flex>
                         <ToastActionButtons actionButtons={actionButtons} />

--- a/web_ui/packages/ui/src/toast/toast.module.scss
+++ b/web_ui/packages/ui/src/toast/toast.module.scss
@@ -32,36 +32,36 @@
     }
 }
 
-.closeIcon {
-    color: var(--closeIconColor);
+.icon {
+    fill: var(--iconColor);
 }
 
 .info {
     --backgroundColor: var(--energy-blue-shade);
     --textColor: var(--spectrum-global-color-gray-900);
-    --closeIconColor: var(--spectrum-global-color-gray-900);
+    --iconColor: var(--spectrum-global-color-gray-900);
 }
 
 .warning {
     --backgroundColor: var(--brand-daisy);
     --textColor: var(--spectrum-global-color-gray-50);
-    --closeIconColor: var(--spectrum-global-color-gray-50);
+    --iconColor: var(--spectrum-global-color-gray-50);
 }
 
 .error {
     --backgroundColor: var(--brand-coral-coral-shade1);
     --textColor: var(--spectrum-global-color-gray-900);
-    --closeIconColor: var(--spectrum-global-color-gray-900);
+    --iconColor: var(--spectrum-global-color-gray-900);
 }
 
 .success {
     --backgroundColor: var(--brand-moss);
     --textColor: var(--spectrum-global-color-gray-900);
-    --closeIconColor: var(--spectrum-global-color-gray-900);
+    --iconColor: var(--spectrum-global-color-gray-900);
 }
 
 .neutral {
     --backgroundColor: var(--spectrum-global-color-gray-400);
     --textColor: var(--spectrum-global-color-gray-900);
-    --closeIconColor: var(--spectrum-global-color-gray-900);
+    --iconColor: var(--spectrum-global-color-gray-900);
 }


### PR DESCRIPTION
## 📝 Description

I noticed that in geti tune we don't specify css rule `svg { fill: currentColor }` and the colors for toast were not propagated properly. To fix it I decided to set colors explicitly so we won't have further regressions in this context.

<!--  
Provide a clear summary of the changes and the context behind them. Describe **what** was changed, **why** it was needed, and **how** the changes address the issue or add value.

If the PR addresses a specific GitHub issue, link it through the 'Development' panel on the side.
This will ensure that the issue is automatically closed after the PR is merged.
Alternatively, include one of the special GitHub keywords in the description, for example:
- Fixes #<issue_number>
- Closes #<issue_number>
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🔨 **Refactor** – Non-breaking change which refactors the code base

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [X] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and meaningful
- [X] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [X] ✅ I have added tests that prove my fix is effective or my feature works
