### PR TITLE
chore: Move eslint jest rule from geti/eslint to geti classic

### DIFF
--- a/web_ui/eslint.config.js
+++ b/web_ui/eslint.config.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
 import sharedEslintConfig from '@geti/config/lint';
+import jest from 'eslint-plugin-jest';
 
 const filename = fileURLToPath(import.meta.url);
 const dirname = path.dirname(filename);
@@ -18,6 +19,19 @@ const compat = new FlatCompat({
 
 export default [
     ...sharedEslintConfig,
+    {
+        files: ['**/*.test.tsx', '**/*.test.ts'],
+        plugins: {
+            jest,
+        },
+        rules: {
+            'jest/no-disabled-tests': 'error',
+            'jest/no-focused-tests': 'error',
+            'jest/no-identical-title': 'error',
+            'jest/prefer-to-have-length': 'warn',
+            'jest/valid-expect': 'error',
+        },
+    },
     {
         rules: {
             'no-restricted-imports': [

--- a/web_ui/packages/config/lint/eslint.config.js
+++ b/web_ui/packages/config/lint/eslint.config.js
@@ -11,7 +11,6 @@ import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import header from 'eslint-plugin-header';
 import _import from 'eslint-plugin-import';
-import jest from 'eslint-plugin-jest';
 import jsxA11Y from 'eslint-plugin-jsx-a11y';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
@@ -99,7 +98,6 @@ export default [
     {
         plugins: {
             import: fixupPluginRules(_import),
-            jest,
             'jsx-a11y': fixupPluginRules(jsxA11Y),
             '@typescript-eslint': fixupPluginRules(typescriptEslint),
             header,
@@ -168,12 +166,6 @@ export default [
                     ignoreRestSiblings: true,
                 },
             ],
-
-            'jest/no-disabled-tests': 'error',
-            'jest/no-focused-tests': 'error',
-            'jest/no-identical-title': 'error',
-            'jest/prefer-to-have-length': 'warn',
-            'jest/valid-expect': 'error',
 
             'import/extensions': [
                 'error',


### PR DESCRIPTION
The issue was that when consumer of geti/packages was not using jest, we were enforcing it by eslint-jest rule.

## 📝 Description

<!--  
Provide a clear summary of the changes and the context behind them. Describe **what** was changed, **why** it was needed, and **how** the changes address the issue or add value.

If the PR addresses a specific GitHub issue, link it through the 'Development' panel on the side.
This will ensure that the issue is automatically closed after the PR is merged.
Alternatively, include one of the special GitHub keywords in the description, for example:
- Fixes #<issue_number>
- Closes #<issue_number>
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🔨 **Refactor** – Non-breaking change which refactors the code base

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [X] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
