### PR TITLE
refactor: Replace `allotment` with `react-resizable-panels`

### DIFF
--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -55,6 +55,7 @@
         "react-error-boundary": "^3.1.4",
         "react-hotkeys-hook": "^4.6.1",
         "react-oidc-context": "^2.3.1",
+        "react-resizable-panels": "^3.0.4",
         "react-router-dom": "^6.30.0",
         "react-stately": "^3.40.0",
         "react-webcam": "^7.2.0",
@@ -20545,6 +20546,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.4.tgz",
+      "integrity": "sha512-8Y4KNgV94XhUvI2LeByyPIjoUJb71M/0hyhtzkHaqpVHs+ZQs8b627HmzyhmVYi3C9YP6R+XD1KmG7hHjEZXFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-router": {

--- a/web_ui/package-lock.json
+++ b/web_ui/package-lock.json
@@ -29,7 +29,6 @@
         "@tanstack/react-query": "^5.74.11",
         "@tanstack/react-query-devtools": "^5.74.11",
         "@wessberg/pointer-events": "^1.0.9",
-        "allotment": "^1.20.3",
         "axios": "^1.9.0",
         "clsx": "^2.1.1",
         "comlink": "^4.4.2",
@@ -3609,10 +3608,6 @@
       "version": "7.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@juggle/resize-observer": {
-      "version": "3.4.0",
-      "license": "Apache-2.0"
     },
     "node_modules/@lezer/common": {
       "version": "1.2.3",
@@ -10968,24 +10963,6 @@
         }
       }
     },
-    "node_modules/allotment": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/allotment/-/allotment-1.20.3.tgz",
-      "integrity": "sha512-JCnklt7j0OsyDjD7A9AdT6wqJ3FSoo1ASV6w02Am02lo6NwO25yhG1DcWW8ueBV38ppXQmvrXBXuzX7iVkq6Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "classnames": "^2.3.0",
-        "eventemitter3": "^5.0.0",
-        "lodash.clamp": "^4.0.0",
-        "lodash.debounce": "^4.0.0",
-        "lodash.isequal": "^4.5.0",
-        "use-resize-observer": "^9.0.0"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "dev": true,
@@ -12022,10 +11999,6 @@
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.3.1",
-      "license": "MIT"
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
@@ -14116,10 +14089,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -17848,16 +17817,8 @@
         "lodash._basetostring": "~4.12.0"
       }
     },
-    "node_modules/lodash.clamp": {
-      "version": "4.0.3",
-      "license": "MIT"
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -23334,17 +23295,6 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/use-resize-observer": {
-      "version": "9.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@juggle/resize-observer": "^3.3.1"
-      },
-      "peerDependencies": {
-        "react": "16.8.0 - 18",
-        "react-dom": "16.8.0 - 18"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -27,7 +27,6 @@
     "@tanstack/react-query": "^5.74.11",
     "@tanstack/react-query-devtools": "^5.74.11",
     "@wessberg/pointer-events": "^1.0.9",
-    "allotment": "^1.20.3",
     "axios": "^1.9.0",
     "clsx": "^2.1.1",
     "comlink": "^4.4.2",

--- a/web_ui/package.json
+++ b/web_ui/package.json
@@ -53,6 +53,7 @@
     "react-error-boundary": "^3.1.4",
     "react-hotkeys-hook": "^4.6.1",
     "react-oidc-context": "^2.3.1",
+    "react-resizable-panels": "^3.0.4",
     "react-router-dom": "^6.30.0",
     "react-stately": "^3.40.0",
     "react-webcam": "^7.2.0",

--- a/web_ui/src/pages/annotator/annotation/pane-list.component.tsx
+++ b/web_ui/src/pages/annotator/annotation/pane-list.component.tsx
@@ -5,8 +5,6 @@ import React, { ReactNode } from 'react';
 
 import { Panel, PanelGroup, PanelResizeHandle } from '../components/sidebar/split-pane/split-pane.component';
 
-import 'allotment/dist/style.css';
-
 interface PaneListProps {
     itemsList: ReactNode;
     listActions: ReactNode;

--- a/web_ui/src/pages/annotator/annotation/pane-list.component.tsx
+++ b/web_ui/src/pages/annotator/annotation/pane-list.component.tsx
@@ -3,7 +3,7 @@
 
 import React, { ReactNode } from 'react';
 
-import { Allotment } from 'allotment';
+import { Panel, PanelGroup, PanelResizeHandle } from '../components/sidebar/split-pane/split-pane.component';
 
 import 'allotment/dist/style.css';
 
@@ -15,15 +15,22 @@ interface PaneListProps {
 
 export const PaneList = ({ itemsList, listActions, thumbnailGrid = null }: PaneListProps) => {
     return (
-        <Allotment vertical>
-            {thumbnailGrid}
+        <PanelGroup direction={'vertical'}>
+            {thumbnailGrid && (
+                <>
+                    <Panel minSize={10} order={1}>
+                        {thumbnailGrid}
+                    </Panel>
+                    <PanelResizeHandle />
+                </>
+            )}
 
-            <Allotment.Pane>
+            <Panel order={2}>
                 <div style={{ height: 'calc(100% - var(--spectrum-global-dimension-size-675))' }}>
                     {listActions}
                     {itemsList}
                 </div>
-            </Allotment.Pane>
-        </Allotment>
+            </Panel>
+        </PanelGroup>
     );
 };

--- a/web_ui/src/pages/annotator/annotation/pane-list.component.tsx
+++ b/web_ui/src/pages/annotator/annotation/pane-list.component.tsx
@@ -16,14 +16,14 @@ export const PaneList = ({ itemsList, listActions, thumbnailGrid = null }: PaneL
         <PanelGroup direction={'vertical'}>
             {thumbnailGrid && (
                 <>
-                    <Panel minSize={10} order={1}>
+                    <Panel minSize={5} order={1}>
                         {thumbnailGrid}
                     </Panel>
                     <PanelResizeHandle />
                 </>
             )}
 
-            <Panel order={2}>
+            <Panel minSize={5} order={2}>
                 <div style={{ height: 'calc(100% - var(--spectrum-global-dimension-size-675))' }}>
                     {listActions}
                     {itemsList}

--- a/web_ui/src/pages/annotator/components/sidebar/sidebar-split-panel.component.tsx
+++ b/web_ui/src/pages/annotator/components/sidebar/sidebar-split-panel.component.tsx
@@ -10,8 +10,6 @@ import { DatasetAccordion } from './dataset/dataset-accordion.component';
 import { SidebarCommonProps } from './sidebar.interface';
 import { Panel, PanelGroup, PanelResizeHandle } from './split-pane/split-pane.component';
 
-import 'allotment/dist/style.css';
-
 /*
     Outer pane = Top list section + Bottom dataset section
     Inner pane = Within the outer pane, holds all the accordions and lists

--- a/web_ui/src/pages/annotator/components/sidebar/sidebar-split-panel.component.tsx
+++ b/web_ui/src/pages/annotator/components/sidebar/sidebar-split-panel.component.tsx
@@ -53,7 +53,7 @@ export const SidebarSplitPanel = ({
             <PanelGroup direction={'vertical'}>
                 {selectedMediaItem !== undefined && showCountingPanel && (
                     <>
-                        <Panel order={1}>
+                        <Panel minSize={3} order={1}>
                             <AnnotationListCounting annotationToolContext={annotationToolContext} />
                         </Panel>
                         <PanelResizeHandle />
@@ -62,7 +62,7 @@ export const SidebarSplitPanel = ({
 
                 {selectedMediaItem !== undefined && showAnnotationPanel && (
                     <>
-                        <Panel order={2}>
+                        <Panel minSize={3} order={2}>
                             <AnnotationListAccordion />
                         </Panel>
                         <PanelResizeHandle />
@@ -71,7 +71,7 @@ export const SidebarSplitPanel = ({
 
                 {showDatasetPanel && (
                     <>
-                        <Panel order={3}>
+                        <Panel minSize={3} order={3}>
                             <DatasetAccordion viewMode={datasetViewMode} setViewMode={setDatasetViewMode} />
                         </Panel>
                     </>

--- a/web_ui/src/pages/annotator/components/sidebar/sidebar-split-panel.component.tsx
+++ b/web_ui/src/pages/annotator/components/sidebar/sidebar-split-panel.component.tsx
@@ -2,13 +2,13 @@
 // LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 
 import { View } from '@geti/ui';
-import { Allotment } from 'allotment';
 
 import { SelectedMediaItem } from '../../providers/selected-media-item-provider/selected-media-item.interface';
 import { AnnotationListAccordion } from './annotations/annotation-list-accordion.component';
 import { AnnotationListCounting } from './annotations/annotation-list-counting.component';
 import { DatasetAccordion } from './dataset/dataset-accordion.component';
 import { SidebarCommonProps } from './sidebar.interface';
+import { Panel, PanelGroup, PanelResizeHandle } from './split-pane/split-pane.component';
 
 import 'allotment/dist/style.css';
 
@@ -52,21 +52,33 @@ export const SidebarSplitPanel = ({
             backgroundColor='gray-200'
             data-testid='sidebar-split-panel'
         >
-            <Allotment vertical>
+            <PanelGroup direction={'vertical'}>
                 {selectedMediaItem !== undefined && showCountingPanel && (
-                    <Allotment.Pane snap>
-                        <AnnotationListCounting annotationToolContext={annotationToolContext} />
-                    </Allotment.Pane>
+                    <>
+                        <Panel collapsible order={1}>
+                            <AnnotationListCounting annotationToolContext={annotationToolContext} />
+                        </Panel>
+                        <PanelResizeHandle />
+                    </>
                 )}
 
-                {selectedMediaItem !== undefined && showAnnotationPanel && <AnnotationListAccordion />}
+                {selectedMediaItem !== undefined && showAnnotationPanel && (
+                    <>
+                        <Panel collapsible order={2}>
+                            <AnnotationListAccordion />
+                        </Panel>
+                        <PanelResizeHandle />
+                    </>
+                )}
 
                 {showDatasetPanel && (
-                    <Allotment.Pane snap>
-                        <DatasetAccordion viewMode={datasetViewMode} setViewMode={setDatasetViewMode} />
-                    </Allotment.Pane>
+                    <>
+                        <Panel collapsible order={3}>
+                            <DatasetAccordion viewMode={datasetViewMode} setViewMode={setDatasetViewMode} />
+                        </Panel>
+                    </>
                 )}
-            </Allotment>
+            </PanelGroup>
         </View>
     );
 };

--- a/web_ui/src/pages/annotator/components/sidebar/sidebar-split-panel.component.tsx
+++ b/web_ui/src/pages/annotator/components/sidebar/sidebar-split-panel.component.tsx
@@ -53,7 +53,7 @@ export const SidebarSplitPanel = ({
             <PanelGroup direction={'vertical'}>
                 {selectedMediaItem !== undefined && showCountingPanel && (
                     <>
-                        <Panel collapsible order={1}>
+                        <Panel order={1}>
                             <AnnotationListCounting annotationToolContext={annotationToolContext} />
                         </Panel>
                         <PanelResizeHandle />
@@ -62,7 +62,7 @@ export const SidebarSplitPanel = ({
 
                 {selectedMediaItem !== undefined && showAnnotationPanel && (
                     <>
-                        <Panel collapsible order={2}>
+                        <Panel order={2}>
                             <AnnotationListAccordion />
                         </Panel>
                         <PanelResizeHandle />
@@ -71,7 +71,7 @@ export const SidebarSplitPanel = ({
 
                 {showDatasetPanel && (
                     <>
-                        <Panel collapsible order={3}>
+                        <Panel order={3}>
                             <DatasetAccordion viewMode={datasetViewMode} setViewMode={setDatasetViewMode} />
                         </Panel>
                     </>

--- a/web_ui/src/pages/annotator/components/sidebar/split-pane/split-pane.component.tsx
+++ b/web_ui/src/pages/annotator/components/sidebar/split-pane/split-pane.component.tsx
@@ -1,0 +1,26 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+import { clsx } from 'clsx';
+import {
+    Panel as ResizablePanel,
+    PanelGroup as ResizablePanelGroup,
+    PanelResizeHandle as ResizablePanelResizableHandle,
+    type PanelGroupProps,
+    type PanelProps,
+    type PanelResizeHandleProps,
+} from 'react-resizable-panels';
+
+import styles from './split-pane.module.scss';
+
+export const Panel = (props: PanelProps) => {
+    return <ResizablePanel {...props} />;
+};
+
+export const PanelGroup = (props: PanelGroupProps) => {
+    return <ResizablePanelGroup {...props} />;
+};
+
+export const PanelResizeHandle = ({ className, ...rest }: PanelResizeHandleProps) => {
+    return <ResizablePanelResizableHandle className={clsx(styles.handle, className)} {...rest} />;
+};

--- a/web_ui/src/pages/annotator/components/sidebar/split-pane/split-pane.module.scss
+++ b/web_ui/src/pages/annotator/components/sidebar/split-pane/split-pane.module.scss
@@ -1,0 +1,22 @@
+.handle {
+    --handleHeight: var(--spectrum-global-dimension-size-100);
+    height: var(--handleHeight);
+    width: 100%;
+    position: relative;
+    cursor: row-resize !important;
+
+    &::before {
+        position: absolute;
+        content: '';
+        width: 100%;
+        top: 50%;
+        transform: translateY(-50%);
+        height: calc(var(--handleHeight) / 4);
+        background-color: var(--spectrum-global-color-gray-500);
+    }
+
+    &:hover::before {
+        --focus-border: #007fd4;
+        background-color: var(--focus-border);
+    }
+}


### PR DESCRIPTION
## 📝 Description

The reason of this change is that `use-resize-observer` that is used by `allotment` package does not support react 19 (and is not actively maintained, https://github.com/johnwalley/allotment/issues/833#issuecomment-2879271232)

<!--  
Provide a clear summary of the changes and the context behind them. Describe **what** was changed, **why** it was needed, and **how** the changes address the issue or add value.

If the PR addresses a specific GitHub issue, link it through the 'Development' panel on the side.
This will ensure that the issue is automatically closed after the PR is merged.
Alternatively, include one of the special GitHub keywords in the description, for example:
- Fixes #<issue_number>
- Closes #<issue_number>
-->

## ✨ Type of Change

Select the type of change your PR introduces:

- [X] 🔨 **Refactor** – Non-breaking change which refactors the code base

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [X] 🔍 PR title is clear and meaningful
- [X] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
