### PR TITLE
Remove pot parameters setting for optimize

### DIFF
--- a/interactive_ai/services/director/app/communication/controllers/training_configuration_controller.py
+++ b/interactive_ai/services/director/app/communication/controllers/training_configuration_controller.py
@@ -84,16 +84,7 @@ class TrainingConfigurationRESTController:
             return rest_view
 
         training_configuration_repo = PartialTrainingConfigurationRepo(project_identifier)
-        task_level_config = training_configuration_repo.get_task_only_configuration(task_id)
-        # create default configuration in case the task exists but has no training configuration yet
-        if isinstance(task_level_config, NullTrainingConfiguration):
-            logger.warning(
-                f"Task training configuration for project `{project_identifier.project_id}` and task `{task_id}` "
-                f"not found, creating default training configuration."
-            )
-            task = task_node_repo.get_by_id(task_id)
-            training_configuration_repo.create_default_task_only_configuration(task)
-            task_level_config = training_configuration_repo.get_task_only_configuration(task_id)
+        task_level_config = training_configuration_repo.get_or_create_task_only_configuration(task_id)
 
         dataset_size = cls._get_dataset_size(
             project_identifier=project_identifier,
@@ -156,7 +147,7 @@ class TrainingConfigurationRESTController:
 
         # configuration is saved as "task level"
         if not update_configuration.model_manifest_id:
-            task_config = training_configuration_repo.get_task_only_configuration(task_id)
+            task_config = training_configuration_repo.get_or_create_task_only_configuration(task_id)
             new_config = ConfigurationOverlayTools.overlay_training_configurations(
                 task_config, update_configuration, validate_full_config=False
             )

--- a/interactive_ai/services/director/app/service/configuration_service.py
+++ b/interactive_ai/services/director/app/service/configuration_service.py
@@ -3,11 +3,7 @@
 import logging
 
 from geti_configuration_tools import ConfigurationOverlayTools
-from geti_configuration_tools.training_configuration import (
-    NullTrainingConfiguration,
-    PartialTrainingConfiguration,
-    TrainingConfiguration,
-)
+from geti_configuration_tools.training_configuration import PartialTrainingConfiguration, TrainingConfiguration
 from geti_supported_models import NullModelManifest, SupportedModels
 
 from communication.exceptions import ModelManifestNotFoundException
@@ -17,7 +13,7 @@ from geti_fastapi_tools.exceptions import ModelNotFoundException
 from geti_types import ID, ModelStorageIdentifier, ProjectIdentifier
 from iai_core.entities.model import NullModel
 from iai_core.entities.model_storage import ModelStorage
-from iai_core.repos import ModelRepo, ModelStorageRepo, TaskNodeRepo
+from iai_core.repos import ModelRepo, ModelStorageRepo
 
 logger = logging.getLogger(__name__)
 
@@ -56,16 +52,7 @@ class ConfigurationService:
             }
         )
         training_configuration_repo = PartialTrainingConfigurationRepo(project_identifier)
-        task_level_config = training_configuration_repo.get_task_only_configuration(task_id)
-        # create default configuration in case the task exists but has no training configuration yet
-        if isinstance(task_level_config, NullTrainingConfiguration):
-            logger.warning(
-                f"Task training configuration for project `{project_identifier.project_id}` and task `{task_id}` "
-                f"not found, creating default training configuration."
-            )
-            task = TaskNodeRepo(project_identifier).get_by_id(task_id)
-            training_configuration_repo.create_default_task_only_configuration(task)
-            task_level_config = training_configuration_repo.get_task_only_configuration(task_id)
+        task_level_config = training_configuration_repo.get_or_create_task_only_configuration(task_id)
 
         algo_level_config = (
             training_configuration_repo.get_by_model_manifest_id(model_manifest_id) if model_manifest_id else None

--- a/interactive_ai/services/director/app/service/configuration_service.py
+++ b/interactive_ai/services/director/app/service/configuration_service.py
@@ -1,7 +1,13 @@
 # Copyright (C) 2022-2025 Intel Corporation
 # LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+import logging
+
 from geti_configuration_tools import ConfigurationOverlayTools
-from geti_configuration_tools.training_configuration import PartialTrainingConfiguration, TrainingConfiguration
+from geti_configuration_tools.training_configuration import (
+    NullTrainingConfiguration,
+    PartialTrainingConfiguration,
+    TrainingConfiguration,
+)
 from geti_supported_models import NullModelManifest, SupportedModels
 
 from communication.exceptions import ModelManifestNotFoundException
@@ -11,7 +17,9 @@ from geti_fastapi_tools.exceptions import ModelNotFoundException
 from geti_types import ID, ModelStorageIdentifier, ProjectIdentifier
 from iai_core.entities.model import NullModel
 from iai_core.entities.model_storage import ModelStorage
-from iai_core.repos import ModelRepo, ModelStorageRepo
+from iai_core.repos import ModelRepo, ModelStorageRepo, TaskNodeRepo
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigurationService:
@@ -49,6 +57,16 @@ class ConfigurationService:
         )
         training_configuration_repo = PartialTrainingConfigurationRepo(project_identifier)
         task_level_config = training_configuration_repo.get_task_only_configuration(task_id)
+        # create default configuration in case the task exists but has no training configuration yet
+        if isinstance(task_level_config, NullTrainingConfiguration):
+            logger.warning(
+                f"Task training configuration for project `{project_identifier.project_id}` and task `{task_id}` "
+                f"not found, creating default training configuration."
+            )
+            task = TaskNodeRepo(project_identifier).get_by_id(task_id)
+            training_configuration_repo.create_default_task_only_configuration(task)
+            task_level_config = training_configuration_repo.get_task_only_configuration(task_id)
+
         algo_level_config = (
             training_configuration_repo.get_by_model_manifest_id(model_manifest_id) if model_manifest_id else None
         )

--- a/interactive_ai/services/director/app/storage/repos/partial_training_configuration_repo.py
+++ b/interactive_ai/services/director/app/storage/repos/partial_training_configuration_repo.py
@@ -97,9 +97,10 @@ class PartialTrainingConfigurationRepo(ProjectBasedSessionRepo[PartialTrainingCo
         task_level_config = self.get_one(extra_filter=task_filter)
         # create default configuration in case the task exists but has no training configuration yet
         if isinstance(task_level_config, NullTrainingConfiguration) and TaskNodeRepo(self.identifier).exists(task_id):
+            sanitized_task_id = str(task_id).replace("\r", "").replace("\n", "").replace("\t", "")
             logger.warning(
-                f"Task training configuration for project `{self.identifier.project_id}` and task `{task_id}` "
-                f"not found, creating default training configuration."
+                f"Task training configuration for project `{self.identifier.project_id}` and task "
+                f"`{sanitized_task_id}` not found, creating default training configuration."
             )
             task = TaskNodeRepo(self.identifier).get_by_id(task_id)
             self.create_default_task_only_configuration(task)

--- a/interactive_ai/services/director/app/storage/repos/partial_training_configuration_repo.py
+++ b/interactive_ai/services/director/app/storage/repos/partial_training_configuration_repo.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2022-2025 Intel Corporation
 # LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
-
+import logging
 from collections.abc import Callable, Sequence
 
 from geti_configuration_tools.training_configuration import (
@@ -23,9 +23,12 @@ from storage.mappers.partial_training_configuration_mapper import PartialTrainin
 
 from geti_types import ID, ProjectIdentifier, Session
 from iai_core.entities.task_node import TaskNode
+from iai_core.repos import TaskNodeRepo
 from iai_core.repos.base import ProjectBasedSessionRepo
 from iai_core.repos.mappers import IDToMongo
 from iai_core.repos.mappers.cursor_iterator import CursorIterator
+
+logger = logging.getLogger(__name__)
 
 
 class PartialTrainingConfigurationRepo(ProjectBasedSessionRepo[PartialTrainingConfiguration]):
@@ -70,16 +73,38 @@ class PartialTrainingConfigurationRepo(ProjectBasedSessionRepo[PartialTrainingCo
             cursor=mongo_cursor, mapper=PartialTrainingConfigurationToMongo, parameter=None
         )
 
-    def get_task_only_configuration(self, task_id: ID) -> PartialTrainingConfiguration:
+    @staticmethod
+    def _task_only_filter(task_id: ID) -> dict:
+        """
+        Returns a filter dictionary to find task-level configurations without an associated model manifest ID.
+
+        :param task_id: The task ID to search for.
+        :return: A dictionary representing the filter
+        """
+        return {"task_id": IDToMongo.forward(instance=task_id), "model_manifest_id": {"$exists": False}}
+
+    def get_or_create_task_only_configuration(self, task_id: ID) -> PartialTrainingConfiguration:
         """
         Get a partial training configuration that is only applied to the specified task ID.
         This returns task-level configuration that does not have an associated model manifest ID.
 
+        If task-level configuration does not exist, but the task exists, a default configuration is created.
+
         :param task_id: The task ID to search for.
         :return: A partial training configuration object if found, otherwise NullTrainingConfiguration.
         """
-        task_filter = {"task_id": IDToMongo.forward(instance=task_id), "model_manifest_id": {"$exists": False}}
-        return self.get_one(extra_filter=task_filter)
+        task_filter = self._task_only_filter(task_id=task_id)
+        task_level_config = self.get_one(extra_filter=task_filter)
+        # create default configuration in case the task exists but has no training configuration yet
+        if isinstance(task_level_config, NullTrainingConfiguration) and TaskNodeRepo(self.identifier).exists(task_id):
+            logger.warning(
+                f"Task training configuration for project `{self.identifier.project_id}` and task `{task_id}` "
+                f"not found, creating default training configuration."
+            )
+            task = TaskNodeRepo(self.identifier).get_by_id(task_id)
+            self.create_default_task_only_configuration(task)
+            task_level_config = self.get_or_create_task_only_configuration(task_id)
+        return task_level_config
 
     def get_by_model_manifest_id(self, model_manifest_id: str) -> PartialTrainingConfiguration:
         """
@@ -100,7 +125,8 @@ class PartialTrainingConfigurationRepo(ProjectBasedSessionRepo[PartialTrainingCo
 
         :param task: The task for which to create a configuration
         """
-        exists = not isinstance(self.get_task_only_configuration(task_id=task.id_), NullTrainingConfiguration)
+        task_filter = self._task_only_filter(task_id=task.id_)
+        exists = not isinstance(self.get_one(extra_filter=task_filter), NullTrainingConfiguration)
         if exists:
             return
 

--- a/interactive_ai/services/director/tests/unit/communication/rest_controllers/test_training_configuration_controller.py
+++ b/interactive_ai/services/director/tests/unit/communication/rest_controllers/test_training_configuration_controller.py
@@ -249,7 +249,7 @@ class TestTrainingConfigurationController:
             )
 
         # Assert
-        updated_config = repo.get_task_only_configuration(
+        updated_config = repo.get_or_create_task_only_configuration(
             task_id=fxt_training_configuration_task_level.task_id,
         )
 


### PR DESCRIPTION
## 📝 Description

Bug: optimize cannot start if missing `training_configuration` docs. 
This is caused when trying to pull legacy parameters in order to get the POT parameters. However, they are not actually utilized anymore and can be removed.

Update: changed `get_task_only_configuration` to `get_or_create_task_only_configuration` since both optimize and model test jobs need dataset filtering parameters.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [x] ✅ I have added tests that prove my fix is effective or my feature works
