### PR TITLE
Dev proxy: try parsing content so it does not fail when parsing text

### DIFF
--- a/web_ui/dev-proxy.ts
+++ b/web_ui/dev-proxy.ts
@@ -66,13 +66,19 @@ export const devProxy: ProxyConfig = [
                 return buffer;
             }
 
-            const originalFeatureFlags = JSON.parse(buffer.toString('utf8'));
+            const content = buffer.toString('utf8');
             try {
-                const featureFlags = JSON.parse(String(fs.readFileSync('./dev-feature-flags.json')));
+                const originalFeatureFlags = JSON.parse(content);
+                try {
+                    const featureFlags = JSON.parse(String(fs.readFileSync('./dev-feature-flags.json')));
 
-                return JSON.stringify({ ...originalFeatureFlags, ...featureFlags });
-            } catch {
-                return JSON.stringify(originalFeatureFlags);
+                    return JSON.stringify({ ...originalFeatureFlags, ...featureFlags });
+                } catch {
+                    return JSON.stringify(originalFeatureFlags);
+                }
+            } catch (e) {
+                console.error('Could not parse feature flags', content, e);
+                return JSON.stringify({});
             }
         }),
     },


### PR DESCRIPTION
This prevents an annoying bug where the dev proxy can't parse a text content when the server returns text at which `JSON.parse` throws an error and the dev server stops running.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
