### PR TITLE
Add `useZoomState` hook for directly accessing scale and translation values

### DIFF
--- a/web_ui/src/pages/annotator/annotation/labels/labels.test.tsx
+++ b/web_ui/src/pages/annotator/annotation/labels/labels.test.tsx
@@ -30,7 +30,7 @@ jest.mock('../../providers/task-chain-provider/task-chain-provider.component', (
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
     ...jest.requireActual('./../../zoom/zoom-provider.component'),
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 jest.mock('../../providers/task-provider/task-provider.component', () => ({

--- a/web_ui/src/pages/annotator/annotation/layers/layers.test.tsx
+++ b/web_ui/src/pages/annotator/annotation/layers/layers.test.tsx
@@ -40,7 +40,7 @@ jest.mock('../../providers/task-chain-provider/utils', () => ({
 
 jest.mock('../../zoom/zoom-provider.component', () => ({
     ...jest.requireActual('../../zoom/zoom-provider.component'),
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 describe('Layers', () => {

--- a/web_ui/src/pages/annotator/annotation/shapes/pose-edges.component.tsx
+++ b/web_ui/src/pages/annotator/annotation/shapes/pose-edges.component.tsx
@@ -11,7 +11,7 @@ import { isKeypointTask } from '../../../../core/projects/utils';
 import { useSelected } from '../../../../providers/selected-provider/selected-provider.component';
 import { useProject } from '../../../project-details/providers/project-provider/project-provider.component';
 import { getOuterPaddedBoundingBox, getPointsEdges } from '../../tools/keypoint-tool/utils';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { KeypointProps } from './shape.interface';
 import { svgShadow } from './util';
 
@@ -24,7 +24,7 @@ interface PoseEdgesProps extends KeypointProps {
 
 export const PoseEdges = ({ shape, boundingBox, showBoundingBox = true }: PoseEdgesProps) => {
     const { project } = useProject();
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
     const { isSelected } = useSelected();
     const keypointTask = project.tasks.find(isKeypointTask);
 

--- a/web_ui/src/pages/annotator/annotation/shapes/pose-keypoints.component.tsx
+++ b/web_ui/src/pages/annotator/annotation/shapes/pose-keypoints.component.tsx
@@ -9,7 +9,7 @@ import { KeypointNode } from '../../../../core/annotations/shapes.interface';
 import { useIsHovered } from '../../../../providers/hovered-provider/hovered-provider.component';
 import { useSelected } from '../../../../providers/selected-provider/selected-provider.component';
 import { KEYPOINT_RADIUS } from '../../../utils';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { KeypointProps } from './shape.interface';
 import { svgShadow } from './util';
 
@@ -44,7 +44,7 @@ export const PoseKeypoints = ({ shape }: KeypointProps) => {
 };
 
 export const PoseKeypointVisibility = ({ point, radius, ...svgProps }: PoseKeypointProps) => {
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
     const { fill, stroke, isPointActive } = usePointFillAndStroke(point);
 
     const occludedIconSize = 18 / zoomState.zoom;
@@ -67,7 +67,7 @@ export const PoseKeypointVisibility = ({ point, radius, ...svgProps }: PoseKeypo
 };
 
 export const PoseKeypoint = ({ point, radius = KEYPOINT_RADIUS, ...svgProps }: PoseKeypointProps) => {
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
     const { isPointActive, fill, stroke } = usePointFillAndStroke(point);
 
     const strokeWidth = radius * 0.4;

--- a/web_ui/src/pages/annotator/annotator-canvas.test.tsx
+++ b/web_ui/src/pages/annotator/annotator-canvas.test.tsx
@@ -54,6 +54,7 @@ jest.mock('./providers/task-provider/task-provider.component', () => ({
 
 jest.mock('./zoom/zoom-provider.component', () => ({
     useZoom: jest.fn(),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 jest.mock('./hooks/use-annotator-scene-interaction-state.hook', () => ({
@@ -178,7 +179,6 @@ describe('Annotator canvas', (): void => {
     beforeEach(() => {
         (useZoom as jest.Mock).mockImplementation(() => ({
             setZoomTarget: jest.fn(),
-            zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } },
         }));
 
         jest.mocked(useTaskChain).mockImplementation(() => ({

--- a/web_ui/src/pages/annotator/components/annotator-preview/preview-canvas-content.component.tsx
+++ b/web_ui/src/pages/annotator/components/annotator-preview/preview-canvas-content.component.tsx
@@ -23,7 +23,7 @@ import { getGlobalAnnotations, getPreviousTask } from '../../providers/task-chai
 import { useTask } from '../../providers/task-provider/task-provider.component';
 import { filterForExplanation, filterForSelectedTask, filterHidden, isPredictionAnnotation } from '../../utils';
 import { TransformZoomAnnotation } from '../../zoom/transform-zoom-annotation.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { ExplanationWithOpacity } from '../explanation/explanation.component';
 
 import classes from './preview-canvas-content.module.scss';
@@ -43,7 +43,7 @@ export const PreviewCanvasContent = ({
 }: PreviewCanvasContentProps) => {
     const { image, roi } = useROI();
     const { inputs } = useTaskChain();
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
     const { tasks, selectedTask } = useTask();
     const { canvasSettingsState } = useAnnotatorCanvasSettings();
     const { showOverlapAnnotations } = useExplanationOpacity();

--- a/web_ui/src/pages/annotator/components/footer/annotator-footer.component.tsx
+++ b/web_ui/src/pages/annotator/components/footer/annotator-footer.component.tsx
@@ -9,7 +9,7 @@ import { clsx } from 'clsx';
 import { MediaItem } from '../../../../core/media/media.interface';
 import { isVideo, isVideoFrame } from '../../../../core/media/video.interface';
 import { useProject } from '../../../project-details/providers/project-provider/project-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { FitImageToScreenButton } from '../fit-image-to-screen-button/fit-image-to-screen-button.component';
 import { MediaItemImageMetadata } from './media-item-image-metadata.component';
 import { MediaItemVideoMetadata } from './media-item-video-metadata.component';
@@ -25,9 +25,7 @@ interface CustomFooterProps extends Omit<FooterProps, 'children'> {
 }
 
 export const Footer = ({ selectedItem, areActionsDisabled = false, children, ...footerProps }: CustomFooterProps) => {
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const { project, isTaskChainProject } = useProject();
 

--- a/web_ui/src/pages/annotator/components/footer/annotator-footer.test.tsx
+++ b/web_ui/src/pages/annotator/components/footer/annotator-footer.test.tsx
@@ -30,7 +30,7 @@ jest.mock('../../../project-details/providers/project-provider/project-provider.
 }));
 
 jest.mock('../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1 } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 describe('Footer', () => {

--- a/web_ui/src/pages/annotator/components/range-based-video-player/transform-zoom.component.tsx
+++ b/web_ui/src/pages/annotator/components/range-based-video-player/transform-zoom.component.tsx
@@ -7,13 +7,14 @@ import { TransformComponent } from 'react-zoom-pan-pinch';
 
 import { MediaItem } from '../../../../core/media/media.interface';
 import { useSyncScreenSize } from '../../zoom/use-sync-screen-size.hook';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoom, useZoomState } from '../../zoom/zoom-provider.component';
 
 import zoomClasses from '../../zoom/transform-zoom-annotation.module.scss';
 
 export const TransformZoom: FC<PropsWithChildren<{ mediaItem: MediaItem }>> = ({ children, mediaItem }) => {
     const ref = useSyncScreenSize();
-    const { isPanning, isPanningDisabled, setZoomTarget, zoomState } = useZoom();
+    const { isPanning, isPanningDisabled, setZoomTarget } = useZoom();
+    const zoomState = useZoomState();
 
     const style = { '--zoom-level': zoomState.zoom } as CSSProperties;
     const enableDragCursorIcon = !isPanningDisabled && isPanning;

--- a/web_ui/src/pages/annotator/hooks/use-copy-paste-annotation/use-copy-paste-annotation.hook.test.tsx
+++ b/web_ui/src/pages/annotator/hooks/use-copy-paste-annotation/use-copy-paste-annotation.hook.test.tsx
@@ -47,9 +47,7 @@ jest.mock('@geti/ui', () => ({
 
 jest.mock('../../zoom/zoom-provider.component', () => ({
     ...jest.requireActual('../../zoom/zoom-provider.component'),
-    useZoom: jest.fn(() => ({
-        zoomState: { zoom: 1 },
-    })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 const mockedUser = getMockedUser();

--- a/web_ui/src/pages/annotator/hooks/use-copy-paste-annotation/use-copy-paste-annotation.hook.ts
+++ b/web_ui/src/pages/annotator/hooks/use-copy-paste-annotation/use-copy-paste-annotation.hook.ts
@@ -26,7 +26,7 @@ import { useROI } from '../../providers/region-of-interest-provider/region-of-in
 import { useTask } from '../../providers/task-provider/task-provider.component';
 import { isShapePartiallyWithinROI, removeOffLimitPoints, translateAnnotation } from '../../tools/utils';
 import { createAnnotation } from '../../utils';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { useAnnotatorHotkeys } from '../use-hotkeys-configuration.hook';
 import { getTranslateVector, hasValidLabelsAndStructure } from './utils';
 
@@ -54,9 +54,7 @@ export const useCopyPasteAnnotation = ({
     const { selectedTask } = useTask();
     const { organizationId } = useOrganizationIdentifier();
 
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const isNotClassificationTask = !(selectedTask && isClassificationDomain(selectedTask.domain));
     // Todo: This will be removed once support for multiple keypoint annotations is implemented

--- a/web_ui/src/pages/annotator/providers/annotator-context-menu-provider/annotation-context-menu.component.tsx
+++ b/web_ui/src/pages/annotator/providers/annotator-context-menu-provider/annotation-context-menu.component.tsx
@@ -16,7 +16,7 @@ import { AnnotationToolContext } from '../../core/annotation-tool-context.interf
 import { useAnnotatorContextMenu } from '../../providers/annotator-context-menu-provider/annotator-context-menu-provider.component';
 import { useIsSelectionToolActive } from '../../tools/selecting-tool/selecting-state-provider.component';
 import { SelectingToolType } from '../../tools/selecting-tool/selecting-tool.enums';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { useAnnotationContextMenu } from './use-annotation-context-menu.hook';
 import { useToolContextMenu } from './use-tool-context-menu.hook';
 
@@ -48,9 +48,7 @@ export const AnnotationContextMenu = ({
 
     const { handleShowToolContextMenu } = useToolContextMenu({ annotationToolContext });
 
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const { hideContextMenu, contextConfig } = useAnnotatorContextMenu();
 

--- a/web_ui/src/pages/annotator/tools/bounding-box/bounding-box-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/bounding-box/bounding-box-tool.component.tsx
@@ -9,7 +9,7 @@ import { DOMAIN } from '../../../../core/projects/core.interface';
 import { runWhen } from '../../../../shared/utils';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { useTask } from '../../providers/task-provider/task-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { DrawingBox } from '../drawing-box/drawing-box.component';
 import { ToolAnnotationContextProps } from '../tools.interface';
 import { convertToolShapeToGetiShape, drawingStyles, isShapeWithinRoi } from '../utils';
@@ -26,9 +26,7 @@ export const BoundingBoxTool = ({ annotationToolContext }: ToolAnnotationContext
         scene.addShapes([convertToolShapeToGetiShape(rect)]);
     });
 
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const styles = drawingStyles(defaultLabel);
 

--- a/web_ui/src/pages/annotator/tools/bounding-box/bounding-box-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/bounding-box/bounding-box-tool.test.tsx
@@ -29,7 +29,7 @@ jest.mock('../../providers/region-of-interest-provider/region-of-interest-provid
 }));
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 jest.mock('../../providers/task-provider/task-provider.component', () => ({

--- a/web_ui/src/pages/annotator/tools/circle-tool/circle-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/circle-tool/circle-tool.component.tsx
@@ -6,7 +6,7 @@ import { CircleSizePreview } from '../../components/circle-size-preview/circle-s
 import { ToolType } from '../../core/annotation-tool-context.interface';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { useTask } from '../../providers/task-provider/task-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { ToolAnnotationContextProps } from '../tools.interface';
 import { drawingStyles, isShapeWithinRoi } from '../utils';
 import { useCircleState } from './circle-state-provider.component';
@@ -15,9 +15,7 @@ import { DrawingCircle } from './drawing-circle.component';
 export const CircleTool = ({ annotationToolContext }: ToolAnnotationContextProps) => {
     const { defaultLabel } = useTask();
     const { scene, updateToolSettings } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
     const { roi, image } = useROI();
     const styles = drawingStyles(defaultLabel);
     const { isBrushSizePreviewVisible, circleRadiusSize, setCircleRadiusSize, maxCircleRadius } = useCircleState();

--- a/web_ui/src/pages/annotator/tools/circle-tool/circle-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/circle-tool/circle-tool.test.tsx
@@ -33,7 +33,7 @@ jest.mock('../../providers/annotation-tool-provider/annotation-tool-provider.com
 }));
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 const renderApp = async (annotationToolContext: AnnotationToolContext) => {

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-annotation-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-annotation-tool.component.tsx
@@ -13,7 +13,7 @@ import { ToolType } from '../../core/annotation-tool-context.interface';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { getGlobalAnnotations } from '../../providers/task-chain-provider/utils';
 import { useTask } from '../../providers/task-provider/task-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { SelectingToolType } from '../selecting-tool/selecting-tool.enums';
 import { ToolAnnotationContextProps } from '../tools.interface';
 import { EditBoundingBox as EditBoundingBoxTool } from './edit-bounding-box/edit-bounding-box.component';
@@ -37,9 +37,7 @@ const EditAnnotationToolFactory = ({
     const { tasks, selectedTask } = useTask();
     const task = selectedTask ?? tasks[0];
     const { scene } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const globalAnnotations = getGlobalAnnotations(scene.annotations, roi, task);
 

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-circle/edit-circle.component.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-circle/edit-circle.component.tsx
@@ -12,7 +12,7 @@ import { ShapeType } from '../../../../../core/annotations/shapetype.enum';
 import { Labels } from '../../../annotation/labels/labels.component';
 import { AnnotationToolContext } from '../../../core/annotation-tool-context.interface';
 import { useROI } from '../../../providers/region-of-interest-provider/region-of-interest-provider.component';
-import { useZoom } from '../../../zoom/zoom-provider.component';
+import { useZoomState } from '../../../zoom/zoom-provider.component';
 import { getMaxCircleRadius, MIN_RADIUS } from '../../circle-tool/utils';
 import { isShapeWithinRoi } from '../../utils';
 import { ResizeAnchorType } from '../resize-anchor.enum';
@@ -71,9 +71,7 @@ export const EditCircle = ({
     disableTranslation = false,
 }: EditCircleProps) => {
     const { scene } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
     const { roi, image } = useROI();
     const [shape, setShape] = useState(annotation.shape);
     const [angle, setAngle] = useState(() => getPreferredAnchorPosition(shape, roi));

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-circle/edit-circle.test.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-circle/edit-circle.test.tsx
@@ -33,7 +33,7 @@ jest.mock('../../../providers/region-of-interest-provider/region-of-interest-pro
 }));
 
 jest.mock('./../../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 const renderApp = async (

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-keypoint/closest-keypoint.component.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-keypoint/closest-keypoint.component.tsx
@@ -8,7 +8,7 @@ import { isFunction } from 'lodash-es';
 
 import { KeypointNode } from '../../../../../core/annotations/shapes.interface';
 import { getRelativePoint } from '../../../../utils';
-import { useZoom } from '../../../zoom/zoom-provider.component';
+import { useZoomState } from '../../../zoom/zoom-provider.component';
 
 interface ClosestPointProps extends Omit<HTMLProps<SVGSVGElement>, 'children'> {
     nodes: KeypointNode[];
@@ -17,7 +17,7 @@ interface ClosestPointProps extends Omit<HTMLProps<SVGSVGElement>, 'children'> {
 }
 
 export const ClosestKeypoint = ({ children, nodes, onClosestElement, ...svgProps }: ClosestPointProps) => {
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
     const containerRef = useRef<SVGSVGElement | null>(null);
     const [closestElement, setClosestElement] = useState<KeypointNode | null>(null);
 

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-keypoint/edit-keypoint-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-keypoint/edit-keypoint-tool.component.tsx
@@ -12,7 +12,7 @@ import { useSelected } from '../../../../../providers/selected-provider/selected
 import { PoseEdges } from '../../../annotation/shapes/pose-edges.component';
 import { AnnotationToolContext } from '../../../core/annotation-tool-context.interface';
 import { useROI } from '../../../providers/region-of-interest-provider/region-of-interest-provider.component';
-import { useZoom } from '../../../zoom/zoom-provider.component';
+import { useZoomState } from '../../../zoom/zoom-provider.component';
 import {
     getAnnotationInBoundingBox,
     getInnerPaddedBoundingBox,
@@ -37,7 +37,7 @@ interface EditKeypointToolProps {
 
 export const EditKeypointTool = ({ annotation, annotationToolContext }: EditKeypointToolProps) => {
     const isEditing = useRef(false);
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
     const { image, roi } = useROI();
     const { isSelected, setSelected, removeSelected } = useSelected();
     const [angle, setAngle] = useState(0);

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-keypoint/edit-pose-point.component.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-keypoint/edit-pose-point.component.tsx
@@ -15,7 +15,7 @@ import { getPointInRoi } from '../../../../utils';
 import { PoseKeypointVisibility } from '../../../annotation/shapes/pose-keypoints.component';
 import { useAnnotatorCanvasSettings } from '../../../providers/annotator-canvas-settings-provider/annotator-canvas-settings-provider.component';
 import { useAnnotatorContextMenu } from '../../../providers/annotator-context-menu-provider/annotator-context-menu-provider.component';
-import { useZoom } from '../../../zoom/zoom-provider.component';
+import { useZoomState } from '../../../zoom/zoom-provider.component';
 import { ResizeAnchorType } from '../resize-anchor.enum';
 
 export interface EditPosePointToolProps {
@@ -52,7 +52,7 @@ export const EditPosePoint = ({
     onToggleVisibility,
 }: EditPosePointToolProps) => {
     const isUpdated = useRef(false);
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
     const containerRef = useRef<SVGGElement | null>(null);
     const { showContextMenu, hideContextMenu, contextConfig } = useAnnotatorContextMenu();
 

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-polygon/edit-polygon.component.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-polygon/edit-polygon.component.tsx
@@ -10,7 +10,7 @@ import { Labels } from '../../../annotation/labels/labels.component';
 import { AnnotationScene } from '../../../core/annotation-scene.interface';
 import { AnnotationToolContext, ToolType } from '../../../core/annotation-tool-context.interface';
 import { useROI } from '../../../providers/region-of-interest-provider/region-of-interest-provider.component';
-import { useZoom } from '../../../zoom/zoom-provider.component';
+import { useZoomState } from '../../../zoom/zoom-provider.component';
 import { SelectingToolType } from '../../selecting-tool/selecting-tool.enums';
 import { isPolygonValid, removeOffLimitPointsPolygon } from '../../utils';
 import { TranslateShape } from '../translate-shape.component';
@@ -47,9 +47,7 @@ export const EditPolygon = ({
     const { roi, image } = useROI();
 
     const { scene, tool, getToolSettings } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     // "removeOffLimitPoints" not only remove offlimit points but also in-between ones,
     // a new point is considered "in-between," and so it gets removed,

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-polygon/edit-polygon.test.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-polygon/edit-polygon.test.tsx
@@ -46,7 +46,8 @@ jest.mock('../../utils', () => ({
 }));
 
 jest.mock('./../../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } }, setIsZoomDisabled: jest.fn() })),
+    useZoom: jest.fn(() => ({ setIsZoomDisabled: jest.fn() })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 interface Point {

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-rotated-bounding-box/edit-rotated-bounding-box.component.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-rotated-bounding-box/edit-rotated-bounding-box.component.tsx
@@ -17,7 +17,7 @@ import { Annotation } from '../../../../../core/annotations/annotation.interface
 import { ShapeType } from '../../../../../core/annotations/shapetype.enum';
 import { AnnotationToolContext } from '../../../core/annotation-tool-context.interface';
 import { useROI } from '../../../providers/region-of-interest-provider/region-of-interest-provider.component';
-import { useZoom } from '../../../zoom/zoom-provider.component';
+import { useZoomState } from '../../../zoom/zoom-provider.component';
 import { isShapeWithinRoi } from '../../utils';
 import { ResizeAnchorType } from '../resize-anchor.enum';
 import { TranslateShape } from '../translate-shape.component';
@@ -44,9 +44,7 @@ export const EditRotatedBoundingBox = ({
     useEffect(() => setShape(annotation.shape), [annotation.shape]);
 
     const { scene } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
     const { roi, image } = useROI();
 
     const onComplete = () => {

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-rotated-bounding-box/edit-rotated-bounding-box.test.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-rotated-bounding-box/edit-rotated-bounding-box.test.tsx
@@ -22,7 +22,7 @@ jest.mock('../../../providers/region-of-interest-provider/region-of-interest-pro
 }));
 
 jest.mock('./../../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 2.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 2.0, translation: { x: 0, y: 0 } })),
 }));
 
 describe('EditRectangleTool', (): void => {

--- a/web_ui/src/pages/annotator/tools/edit-tool/edit-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/edit-tool/edit-tool.test.tsx
@@ -51,7 +51,8 @@ jest.mock('../../providers/region-of-interest-provider/region-of-interest-provid
 }));
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } }, setIsZoomDisabled: jest.fn() })),
+    useZoom: jest.fn(() => ({ setIsZoomDisabled: jest.fn() })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 jest.mock('../../providers/task-provider/task-provider.component', () => ({

--- a/web_ui/src/pages/annotator/tools/eraser-tool/eraser-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/eraser-tool/eraser-tool.component.tsx
@@ -8,7 +8,7 @@ import { getTheTopShapeAt } from '../../../../core/annotations/utils';
 import { isEraserButton } from '../../../buttons-utils';
 import { getRelativePoint } from '../../../utils';
 import { AnnotationScene } from './../../core/annotation-scene.interface';
-import { useZoom } from './../../zoom/zoom-provider.component';
+import { useZoomState } from './../../zoom/zoom-provider.component';
 import { PointerType } from './..//tools.interface';
 
 interface ErasableCanvasProps {
@@ -19,9 +19,7 @@ interface ErasableCanvasProps {
 }
 
 export const EraserTool = ({ canvasRef, annotations, children, scene }: ErasableCanvasProps) => {
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const onPointerMove = (event: PointerEvent<SVGSVGElement>): void => {
         if (canvasRef.current === null) {

--- a/web_ui/src/pages/annotator/tools/eraser-tool/eraser-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/eraser-tool/eraser-tool.test.tsx
@@ -16,7 +16,7 @@ import { PointerType } from '../tools.interface';
 import { EraserTool } from './eraser-tool.component';
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 describe('EraserTool', () => {

--- a/web_ui/src/pages/annotator/tools/grabcut-tool/grabcut-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/grabcut-tool/grabcut-tool.component.tsx
@@ -12,7 +12,7 @@ import { ToolType } from '../../core/annotation-tool-context.interface';
 import { useAddUnfinishedShape } from '../../hooks/use-add-unfinished-shape.hook';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { useTask } from '../../providers/task-provider/task-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { DrawingBox } from '../drawing-box/drawing-box.component';
 import { MarkerTool } from '../marker-tool/marker-tool.component';
 import { Marker } from '../marker-tool/marker-tool.interface';
@@ -55,9 +55,7 @@ export const GrabcutTool = ({ annotationToolContext }: ToolAnnotationContextProp
     const { image } = useROI();
     const { scene, getToolSettings } = annotationToolContext;
     const { sensitivity } = getToolSettings(ToolType.GrabcutTool);
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const {
         toolsState,

--- a/web_ui/src/pages/annotator/tools/grabcut-tool/grabcut-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/grabcut-tool/grabcut-tool.test.tsx
@@ -59,7 +59,7 @@ jest.mock('../../hooks/use-add-unfinished-shape.hook', () => ({
 }));
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 const sensitivity = 10;

--- a/web_ui/src/pages/annotator/tools/keypoint-tool/keypoint-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/keypoint-tool/keypoint-tool.component.tsx
@@ -10,7 +10,7 @@ import { labelFromUser } from '../../../../core/annotations/utils';
 import { PoseEdges } from '../../annotation/shapes/pose-edges.component';
 import { PoseKeypoints } from '../../annotation/shapes/pose-keypoints.component';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { TranslateShape } from '../edit-tool/translate-shape.component';
 import { getBoundingBoxInRoi, getBoundingBoxResizePoints, getClampedBoundingBox } from '../edit-tool/utils';
 import { SvgToolCanvas } from '../svg-tool-canvas.component';
@@ -26,7 +26,7 @@ import {
 } from './utils';
 
 export const KeypointTool = ({ annotationToolContext }: ToolAnnotationContextProps) => {
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
     const { image, roi } = useROI();
     const { templateLabels, templatePoints, currentBoundingBox, setCurrentBoundingBox, setCursorDirection } =
         useKeypointState();

--- a/web_ui/src/pages/annotator/tools/keypoint-tool/keypoint-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/keypoint-tool/keypoint-tool.test.tsx
@@ -29,7 +29,7 @@ jest.mock('../../providers/region-of-interest-provider/region-of-interest-provid
 }));
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 describe('KeypointTool', () => {

--- a/web_ui/src/pages/annotator/tools/polygon-tool/polygon-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/polygon-tool/polygon-tool.component.tsx
@@ -19,7 +19,7 @@ import { usePolygon } from '../../hooks/use-polygon.hook';
 import { useAnnotationScene } from '../../providers/annotation-scene-provider/annotation-scene-provider.component';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { useTask } from '../../providers/task-provider/task-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { PolygonDraw } from '../polygon-draw.component';
 import { SvgToolCanvas } from '../svg-tool-canvas.component';
 import { ToolAnnotationContextProps } from '../tools.interface';
@@ -70,9 +70,7 @@ export const PolygonTool = ({ annotationToolContext }: ToolAnnotationContextProp
     const { setIsDrawing } = useAnnotationScene();
     const ref = useRef<SVGRectElement>({} as SVGRectElement);
     const isClosing = useRef(false);
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const { roi, image } = useROI();
 

--- a/web_ui/src/pages/annotator/tools/polygon-tool/polygon-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/polygon-tool/polygon-tool.test.tsx
@@ -66,7 +66,7 @@ jest.mock('../../providers/region-of-interest-provider/region-of-interest-provid
 }));
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 const mockOptimizePolygon = jest.fn((polygon) => polygon);

--- a/web_ui/src/pages/annotator/tools/ritm-tool/ritm-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/ritm-tool/ritm-tool.component.tsx
@@ -21,7 +21,7 @@ import { ToolType } from '../../core/annotation-tool-context.interface';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { useTaskChain } from '../../providers/task-chain-provider/task-chain-provider.component';
 import { useTask } from '../../providers/task-provider/task-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { DrawingBox } from '../drawing-box/drawing-box.component';
 import { SvgToolCanvas } from '../svg-tool-canvas.component';
 import { PointerType, ToolAnnotationContextProps } from '../tools.interface';
@@ -39,9 +39,7 @@ const MINIMUM_MARGIN = RITM_TEMPLATE_SIZE / 2 + 1;
 export const RITMTool = ({ annotationToolContext }: ToolAnnotationContextProps) => {
     const { defaultLabel, activeDomains } = useTask();
     const { getToolSettings } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const hasRotatedBoundingBoxDomain = activeDomains.includes(DOMAIN.DETECTION_ROTATED_BOUNDING_BOX);
     const outputShape = hasRotatedBoundingBoxDomain ? ShapeType.RotatedRect : ShapeType.Polygon;

--- a/web_ui/src/pages/annotator/tools/ritm-tool/ritm-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/ritm-tool/ritm-tool.test.tsx
@@ -85,7 +85,7 @@ jest.mock('../../providers/task-provider/task-provider.component', () => ({
 }));
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 const mockROI = { x: 0, y: 0, width: 1000, height: 1000 };

--- a/web_ui/src/pages/annotator/tools/rotated-bounding-box-tool/rotated-bounding-box-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/rotated-bounding-box-tool/rotated-bounding-box-tool.component.tsx
@@ -3,7 +3,7 @@
 
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { useTask } from '../../providers/task-provider/task-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { ToolAnnotationContextProps } from '../tools.interface';
 import { drawingStyles } from '../utils';
 import { RotatedDrawingBox } from './rotated-drawing-box.component';
@@ -13,9 +13,7 @@ export const RotatedBoundingBoxTool = ({ annotationToolContext }: ToolAnnotation
     const { scene } = annotationToolContext;
     const { image } = useROI();
     const onComplete = scene.addShapes;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const styles = drawingStyles(defaultLabel);
 

--- a/web_ui/src/pages/annotator/tools/rotated-bounding-box-tool/rotated-bounding-box-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/rotated-bounding-box-tool/rotated-bounding-box-tool.test.tsx
@@ -26,7 +26,7 @@ jest.mock('../../providers/region-of-interest-provider/region-of-interest-provid
 }));
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 const renderApp = async (annotationToolContext: AnnotationToolContext) => {

--- a/web_ui/src/pages/annotator/tools/segment-anything-tool/interactive-segmentation-point.component.tsx
+++ b/web_ui/src/pages/annotator/tools/segment-anything-tool/interactive-segmentation-point.component.tsx
@@ -3,7 +3,7 @@
 
 import { ShapeType } from '../../../../core/annotations/shapetype.enum';
 import { Circle } from '../../annotation/shapes/circle.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { InteractiveAnnotationPoint } from './segment-anything.interface';
 
 interface InteractiveSegmentationPointProps extends InteractiveAnnotationPoint {
@@ -11,9 +11,7 @@ interface InteractiveSegmentationPointProps extends InteractiveAnnotationPoint {
 }
 
 export const InteractiveSegmentationPoint = ({ x, y, positive, isLoading }: InteractiveSegmentationPointProps) => {
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const fill = positive ? 'var(--brand-moss)' : 'var(--brand-coral-cobalt)';
     const radius = 1 / zoom;

--- a/web_ui/src/pages/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/segment-anything-tool/segment-anything-tool.component.tsx
@@ -15,7 +15,7 @@ import { ShapeFactory } from '../../annotation/shapes/factory.component';
 import { ToolType } from '../../core/annotation-tool-context.interface';
 import { useAnnotationToolContext } from '../../providers/annotation-tool-provider/annotation-tool-provider.component';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { SvgToolCanvas } from '../svg-tool-canvas.component';
 import { PointerType } from '../tools.interface';
 import { removeOffLimitPoints, SELECT_ANNOTATION_STYLES } from '../utils';
@@ -43,9 +43,7 @@ const THROTTLE_TIME = 150;
 
 export const SegmentAnythingTool = () => {
     const { image, roi } = useROI();
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const clampPoint = clampPointBetweenImage(image);
 

--- a/web_ui/src/pages/annotator/tools/segment-anything-tool/segment-anything.test.tsx
+++ b/web_ui/src/pages/annotator/tools/segment-anything-tool/segment-anything.test.tsx
@@ -35,7 +35,7 @@ jest.mock('./use-segment-anything-model.hook', () => ({
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
     ...jest.requireActual('./../../zoom/zoom-provider.component'),
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 const NEW_ROI = { x: 0, y: 0, width: 100, height: 100 };

--- a/web_ui/src/pages/annotator/tools/selecting-tool/components/brush-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/selecting-tool/components/brush-tool.component.tsx
@@ -13,7 +13,7 @@ import { CircleSizePreview } from '../../../components/circle-size-preview/circl
 import { useROI } from '../../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { getOutputFromTask } from '../../../providers/task-chain-provider/utils';
 import { useTask } from '../../../providers/task-provider/task-provider.component';
-import { useZoom } from '../../../zoom/zoom-provider.component';
+import { useZoomState } from '../../../zoom/zoom-provider.component';
 import { pointsToCircle } from '../../circle-tool/utils';
 import { PolygonDraw } from '../../polygon-draw.component';
 import { SvgToolCanvas } from '../../svg-tool-canvas.component';
@@ -43,9 +43,7 @@ const getGhostPolygon = (polygon: GhostPolygon | null, annotation: Annotation): 
 export const BrushTool = ({ annotationToolContext, brushSize, showCirclePreview }: BrushToolProps) => {
     const { tasks, selectedTask } = useTask();
     const { scene } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const ref = useRef<SVGRectElement>(null);
     const { roi, image } = useROI();

--- a/web_ui/src/pages/annotator/tools/selecting-tool/components/brush-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/selecting-tool/components/brush-tool.test.tsx
@@ -38,7 +38,7 @@ jest.mock('../../../providers/task-chain-provider/task-chain-provider.component'
 });
 
 jest.mock('./../../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 const polygonAnnotation: Annotation = {

--- a/web_ui/src/pages/annotator/tools/selecting-tool/components/selecting-box-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/selecting-tool/components/selecting-box-tool.component.tsx
@@ -18,7 +18,7 @@ import { useAnnotatorHotkeys } from '../../../hooks/use-hotkeys-configuration.ho
 import { useVisibleAnnotations } from '../../../hooks/use-visible-annotations.hook';
 import { HOTKEY_OPTIONS } from '../../../hot-keys/utils';
 import { useROI } from '../../../providers/region-of-interest-provider/region-of-interest-provider.component';
-import { useZoom } from '../../../zoom/zoom-provider.component';
+import { useZoomState } from '../../../zoom/zoom-provider.component';
 import { SvgToolCanvas } from '../../svg-tool-canvas.component';
 import { ToolAnnotationContextProps } from '../../tools.interface';
 import { SELECT_ANNOTATION_STYLES } from '../../utils';
@@ -58,9 +58,7 @@ export const SelectingBoxTool = ({
     );
     const localCopyOfLastSelectedAnnotations = useRef<AnnotationInterface[] | null>(null);
 
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const handlePointerDown = (event: PointerEvent<SVGSVGElement>): void => {
         const { button, buttons, clientY, clientX, currentTarget, pointerId, shiftKey } = event;

--- a/web_ui/src/pages/annotator/tools/selecting-tool/components/translated-annotations.component.tsx
+++ b/web_ui/src/pages/annotator/tools/selecting-tool/components/translated-annotations.component.tsx
@@ -12,7 +12,7 @@ import { getRelativePoint } from '../../../../utils';
 import { Annotation } from '../../../annotation/annotation.component';
 import { Labels } from '../../../annotation/labels/labels.component';
 import { useROI } from '../../../providers/region-of-interest-provider/region-of-interest-provider.component';
-import { useZoom } from '../../../zoom/zoom-provider.component';
+import { useZoomState } from '../../../zoom/zoom-provider.component';
 import { ToolAnnotationContextProps } from '../../tools.interface';
 import { translateAnnotation } from '../../utils';
 
@@ -33,9 +33,7 @@ export const TranslatedAnnotations = ({
     const {
         scene: { updateAnnotation },
     } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const { image } = useROI();
     const [startPoint, setStartPoint] = useState<Point | null>(null);

--- a/web_ui/src/pages/annotator/tools/selecting-tool/selecting-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/selecting-tool/selecting-tool.component.tsx
@@ -15,7 +15,7 @@ import { useVisibleAnnotations } from '../../hooks/use-visible-annotations.hook'
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { getGlobalAnnotations } from '../../providers/task-chain-provider/utils';
 import { useTask } from '../../providers/task-provider/task-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { PointerEvents, ToolAnnotationContextProps } from '../tools.interface';
 import { SelectingBoxTool } from './components/selecting-box-tool.component';
 import { areAnnotationsIdentical, pointInShape } from './utils';
@@ -45,9 +45,7 @@ export const SelectingTool = ({ annotationToolContext }: ToolAnnotationContextPr
     const {
         scene: { setSelectedAnnotations },
     } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const selectingContainerRef = useRef<SVGSVGElement>(null);
 

--- a/web_ui/src/pages/annotator/tools/selecting-tool/selecting-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/selecting-tool/selecting-tool.test.tsx
@@ -69,7 +69,7 @@ jest.mock('./components/brush-tool.component', () => {
 });
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 const getToolSettings = jest.fn(() => ({ tool: SelectingToolType.SelectionTool }));

--- a/web_ui/src/pages/annotator/tools/selecting-tool/stamp-tool/stamp-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/selecting-tool/stamp-tool/stamp-tool.component.tsx
@@ -9,7 +9,7 @@ import { getRelativePoint } from '../../../../utils';
 import { Annotation } from '../../../annotation/annotation.component';
 import { useROI } from '../../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { createAnnotation } from '../../../utils';
-import { useZoom } from '../../../zoom/zoom-provider.component';
+import { useZoomState } from '../../../zoom/zoom-provider.component';
 import { SvgToolCanvas } from '../../svg-tool-canvas.component';
 import { ToolAnnotationContextProps } from '../../tools.interface';
 import { isPointWithinRoi, removeOffLimitPoints, translateAnnotation } from '../../utils';
@@ -26,9 +26,7 @@ export const StampTool = ({ annotationToolContext }: ToolAnnotationContextProps)
     const [translatedAnnotations, setTranslatedAnnotations] = useState<AnnotationInterface[]>(stampAnnotations);
     const { roi, image } = useROI();
 
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
 
     const handleOnPointerMove = (event: PointerEvent<SVGSVGElement>): void => {
         if (stampToolContainerRef.current === null) {

--- a/web_ui/src/pages/annotator/tools/ssim-tool/ssim-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/ssim-tool/ssim-tool.component.tsx
@@ -13,7 +13,7 @@ import { RotatedRectangle } from '../../annotation/shapes/rotated-rectangle.comp
 import { ToolType } from '../../core/annotation-tool-context.interface';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
 import { useTask } from '../../providers/task-provider/task-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { DrawingCircle } from '../circle-tool/drawing-circle.component';
 import { DrawingBox } from '../drawing-box/drawing-box.component';
 import { ToolAnnotationContextProps } from '../tools.interface';
@@ -26,9 +26,7 @@ import classes from './ssim-tool.module.scss';
 export const SSIMTool = ({ annotationToolContext }: ToolAnnotationContextProps) => {
     const { defaultLabel } = useTask();
     const { scene, getToolSettings } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
     const { roi, image } = useROI();
 
     const { runSSIM, toolState, previewThreshold } = useSSIMState();

--- a/web_ui/src/pages/annotator/tools/ssim-tool/ssim-tool.test.tsx
+++ b/web_ui/src/pages/annotator/tools/ssim-tool/ssim-tool.test.tsx
@@ -50,7 +50,7 @@ jest.mock('../../providers/region-of-interest-provider/region-of-interest-provid
 jest.mock('../../hooks/use-add-unfinished-shape.hook');
 
 jest.mock('./../../zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 jest.mock('../../../../hooks/use-load-ai-webworker/use-load-ai-webworker.hook', () => {

--- a/web_ui/src/pages/annotator/tools/watershed-tool/watershed-tool.component.tsx
+++ b/web_ui/src/pages/annotator/tools/watershed-tool/watershed-tool.component.tsx
@@ -10,7 +10,7 @@ import { CircleSizePreview } from '../../components/circle-size-preview/circle-s
 import { ToolType } from '../../core/annotation-tool-context.interface';
 import { useAddUnfinishedShape } from '../../hooks/use-add-unfinished-shape.hook';
 import { useROI } from '../../providers/region-of-interest-provider/region-of-interest-provider.component';
-import { useZoom } from '../../zoom/zoom-provider.component';
+import { useZoomState } from '../../zoom/zoom-provider.component';
 import { MarkerTool } from '../marker-tool/marker-tool.component';
 import { Marker } from '../marker-tool/marker-tool.interface';
 import { ToolAnnotationContextProps } from '../tools.interface';
@@ -23,9 +23,7 @@ const MIN_NUMBER_OF_REQUIRED_UNIQUE_MARKERS = 2;
 
 export const WatershedTool = ({ annotationToolContext }: ToolAnnotationContextProps) => {
     const { getToolSettings, scene } = annotationToolContext;
-    const {
-        zoomState: { zoom },
-    } = useZoom();
+    const { zoom } = useZoomState();
     const { roi, image } = useROI();
 
     const { shapes, onComplete, runWatershed, reset, setShapes, brushSize, isBrushSizePreviewVisible } =

--- a/web_ui/src/pages/annotator/zoom/zoom-provider.component.tsx
+++ b/web_ui/src/pages/annotator/zoom/zoom-provider.component.tsx
@@ -22,7 +22,6 @@ interface ZoomState {
 }
 
 interface ZoomContextProps {
-    zoomState: ZoomState;
     setScreenSize: Dispatch<SetStateAction<{ width: number; height: number } | undefined>>;
 
     zoomTarget: ZoomTarget;
@@ -144,8 +143,6 @@ export const ZoomProvider = ({ children }: ZoomProviderProps) => {
     const maxScale = Math.round(Math.max(screenSize?.height ?? 1, screenSize?.width ?? 1) / 25);
 
     const value: ZoomContextProps = {
-        zoomState: defaultZoomState,
-
         zoomTarget,
         setZoomTarget,
         setScreenSize,
@@ -188,14 +185,20 @@ export const ZoomProvider = ({ children }: ZoomProviderProps) => {
 
 export const useZoom = (): ZoomContextProps => {
     const context = useContext(ZoomContext);
-    const zoomStateContext = useContext(ZoomStateContext);
 
-    if (context === undefined || zoomStateContext === undefined) {
+    if (context === undefined) {
         throw new MissingProviderError('useZoom', 'ZoomProvider');
     }
 
-    return {
-        ...context,
-        zoomState: zoomStateContext,
-    };
+    return context;
+};
+
+export const useZoomState = (): ZoomState => {
+    const zoomStateContext = useContext(ZoomStateContext);
+
+    if (zoomStateContext === undefined) {
+        throw new MissingProviderError('useZoomState', 'ZoomStateProvider');
+    }
+
+    return zoomStateContext;
 };

--- a/web_ui/src/pages/create-project/components/pose-template/canvas/canvas-template.component.tsx
+++ b/web_ui/src/pages/create-project/components/pose-template/canvas/canvas-template.component.tsx
@@ -15,7 +15,7 @@ import { useSelected } from '../../../../../providers/selected-provider/selected
 import { KeyMap } from '../../../../../shared/keyboard-events/keyboard.interface';
 import { getIds, hasDifferentId } from '../../../../../shared/utils';
 import { ClosestKeypoint } from '../../../../annotator/tools/edit-tool/edit-keypoint/closest-keypoint.component';
-import { useZoom } from '../../../../annotator/zoom/zoom-provider.component';
+import { useZoomState } from '../../../../annotator/zoom/zoom-provider.component';
 import { EdgeLine, getPointInRoi, TemplateState, TemplateStateWithHistory } from '../../../../utils';
 import {
     getDefaultLabelStructure,
@@ -50,7 +50,7 @@ export const CanvasTemplate = ({
     isLabelOptionsEnabled = true,
     onStateUpdate,
 }: CanvasTemplateProps) => {
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
     const { setSelected, isSelected } = useSelected();
     const [visibleLabelId, setVisibleLabelId] = useState<null | string>(null);
     const nextPointName = useRef(points.length + 1);

--- a/web_ui/src/pages/create-project/components/pose-template/canvas/drawing-box.component.tsx
+++ b/web_ui/src/pages/create-project/components/pose-template/canvas/drawing-box.component.tsx
@@ -5,7 +5,7 @@ import { useRef } from 'react';
 
 import { KeypointNode, Point } from '../../../../../core/annotations/shapes.interface';
 import { allowPanning } from '../../../../annotator/tools/utils';
-import { useZoom } from '../../../../annotator/zoom/zoom-provider.component';
+import { useZoomState } from '../../../../annotator/zoom/zoom-provider.component';
 import { getRelativePoint, leftMouseButtonHandler } from '../../../../utils';
 import { getDefaultLabelStructure } from '../util';
 
@@ -17,7 +17,7 @@ interface DrawingBoxProps {
 
 export const DrawingBox = ({ nextPointName, onAddPoint, onPointerMove }: DrawingBoxProps) => {
     const canvasRef = useRef<SVGRectElement>(null);
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
 
     const onPointerDown = leftMouseButtonHandler((event) => {
         event.currentTarget.setPointerCapture(event.pointerId);

--- a/web_ui/src/pages/create-project/components/pose-template/canvas/hidden-edge.component.tsx
+++ b/web_ui/src/pages/create-project/components/pose-template/canvas/hidden-edge.component.tsx
@@ -9,7 +9,7 @@ import { clsx } from 'clsx';
 import { KeypointNode, Point } from '../../../../../core/annotations/shapes.interface';
 import { getMockedKeypointNode } from '../../../../../test-utils/mocked-items-factory/mocked-keypoint';
 import { PoseKeypoint } from '../../../../annotator/annotation/shapes/pose-keypoints.component';
-import { useZoom } from '../../../../annotator/zoom/zoom-provider.component';
+import { useZoomState } from '../../../../annotator/zoom/zoom-provider.component';
 import { getRelativePoint, projectPointOnLine } from '../../../../utils';
 
 import classes from './edge.module.scss';
@@ -24,7 +24,7 @@ export interface HiddenEdgeProps {
 }
 
 export const HiddenEdge = ({ to, from, isHovered, isSelected, onSelect, onNewIntermediatePoint }: HiddenEdgeProps) => {
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
     const containerRef = useRef<SVGRectElement>(null);
     const [ghostPoint, setGhostPoint] = useState<Point | null>(null);
 

--- a/web_ui/src/pages/create-project/components/pose-template/template-footer.component.tsx
+++ b/web_ui/src/pages/create-project/components/pose-template/template-footer.component.tsx
@@ -4,10 +4,10 @@
 import { Content, Divider, Flex, View } from '@geti/ui';
 
 import { ZoomLevel } from '../../../annotator/components/footer/zoom-level/zoom-level.component';
-import { useZoom } from '../../../annotator/zoom/zoom-provider.component';
+import { useZoomState } from '../../../annotator/zoom/zoom-provider.component';
 
 export const TemplateFooter = () => {
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
 
     return (
         <View backgroundColor={'gray-100'}>

--- a/web_ui/src/pages/project-details/components/project-tests/quick-inference/image-section.component.tsx
+++ b/web_ui/src/pages/project-details/components/project-tests/quick-inference/image-section.component.tsx
@@ -18,14 +18,14 @@ import { useAnnotatorCanvasSettings } from '../../../../annotator/providers/anno
 import { useSelectedMediaItem } from '../../../../annotator/providers/selected-media-item-provider/selected-media-item-provider.component';
 import { filterForExplanation } from '../../../../annotator/utils';
 import { TransformZoomAnnotation } from '../../../../annotator/zoom/transform-zoom-annotation.component';
-import { useZoom, ZoomProvider } from '../../../../annotator/zoom/zoom-provider.component';
+import { useZoomState, ZoomProvider } from '../../../../annotator/zoom/zoom-provider.component';
 import { useQuickInference } from './quick-inference-provider.component';
 
 import classes from './quick-inference.module.scss';
 
 const RawCanvas = () => {
     const annotationToolContext = useAnnotationToolContext();
-    const { zoomState } = useZoom();
+    const zoomState = useZoomState();
 
     const { selectedMediaItem } = useSelectedMediaItem();
 

--- a/web_ui/src/pages/shared/zoom/transform-zoom.component.tsx
+++ b/web_ui/src/pages/shared/zoom/transform-zoom.component.tsx
@@ -9,7 +9,7 @@ import { TransformComponent, useControls } from 'react-zoom-pan-pinch';
 import { useAnnotatorHotkeys } from '../../annotator/hooks/use-hotkeys-configuration.hook';
 import { PointerType } from '../../annotator/tools/tools.interface';
 import { useSyncScreenSize } from '../../annotator/zoom/use-sync-screen-size.hook';
-import { useZoom } from '../../annotator/zoom/zoom-provider.component';
+import { useZoom, useZoomState } from '../../annotator/zoom/zoom-provider.component';
 import { isLeftButton, isWheelButton } from '../../buttons-utils';
 
 import classes from './transform-zoom.module.scss';
@@ -27,10 +27,10 @@ export const TransformZoom = ({ children }: { children?: ReactNode }) => {
     const { resetTransform } = useControls();
 
     const ref = useSyncScreenSize();
-    const { setIsPanningDisabled, isPanning, isPanningDisabled, setisDblClickDisabled, isDblClickDisabled, zoomState } =
-        useZoom();
+    const { setIsPanningDisabled, isPanning, isPanningDisabled, setisDblClickDisabled, isDblClickDisabled } = useZoom();
+    const { zoom } = useZoomState();
+    const style = { '--zoom-level': zoom } as CSSProperties;
 
-    const style = { '--zoom-level': zoomState.zoom } as CSSProperties;
     const enableDragCursorIcon = !isPanningDisabled && isPanning;
 
     const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {

--- a/web_ui/src/shared/components/media-item-annotations-preview/media-item-annotations-preview-dialog/media-item-annotations-preview-dialog.test.tsx
+++ b/web_ui/src/shared/components/media-item-annotations-preview/media-item-annotations-preview-dialog/media-item-annotations-preview-dialog.test.tsx
@@ -15,7 +15,7 @@ import { providersRender as render } from '../../../../test-utils/required-provi
 import { MediaItemAnnotationsPreviewDialog } from './media-item-annotations-preview-dialog.component';
 
 jest.mock('../../../../pages/annotator/zoom/zoom-provider.component', () => ({
-    useZoom: jest.fn(() => ({ zoomState: { zoom: 1.0, translation: { x: 0, y: 0 } } })),
+    useZoomState: jest.fn(() => ({ zoom: 1.0, translation: { x: 0, y: 0 } })),
 }));
 
 jest.mock('../../../../pages/project-details/providers/project-provider/project-provider.component', () => ({


### PR DESCRIPTION
This is a follow up of #1216.

Using this hook vs `useZoom` allows us to remove `zoomState` from the `ZoomContextProps` props. This simplifies the provider component and also potentially improves performance as components will have less reasons to rerender.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
