### PR TITLE
GH 1228 weights uploader chart copied to seaweedfs

### DIFF
--- a/deploy/charts/seaweed-fs/Makefile
+++ b/deploy/charts/seaweed-fs/Makefile
@@ -1,3 +1,12 @@
 include ../../../Makefile.shared
 
 COMPONENT_NAME := seaweed-fs
+
+prepare-weights-uploader:
+	@echo "Preparing weights-uploader"
+	# this folder is created in all the other cases by build-chart-default
+	# we have to do it here to able to copy the weights-uploader charts before running build-chart
+	mkdir -p ${CHART_TARGET_DIR}/templates
+	cp -r ../../../platform/services/weights_uploader/.build/chart/templates/* ${CHART_TARGET_DIR}/templates/
+
+build-chart-default: prepare-weights-uploader


### PR DESCRIPTION
We need to copy weights-uploader charts to seaweed prior to running seaweedfs chart build.