### PR TITLE
serializing calls to decoding of video

### DIFF
--- a/interactive_ai/services/resource/app/communication/rest_endpoints/media_endpoints.py
+++ b/interactive_ai/services/resource/app/communication/rest_endpoints/media_endpoints.py
@@ -263,7 +263,7 @@ def get_video_display(  # noqa: ANN201
 
 
 @media_router.get("/media/videos/{video_id}/frames/{frame_index}/display/{display_type}")
-def video_frame_endpoint(
+async def video_frame_endpoint(
     dataset_storage_identifier: Annotated[DatasetStorageIdentifier, Depends(get_dataset_storage_identifier)],
     video_id: Annotated[ID, Depends(get_video_id)],
     frame_index: int,

--- a/interactive_ai/services/resource/chart/values.yaml
+++ b/interactive_ai/services/resource/chart/values.yaml
@@ -4,7 +4,7 @@ imagePullPolicy: IfNotPresent
 
 resources:
   requests:
-    cpu: 1
+    cpu: 1.5
     memory: 1Gi
   limits:
     memory: 3Gi # To be reduced after media upload revamp (CVS-152302)


### PR DESCRIPTION
## 📝 Description

- Fixes #945 

The issue described in the #945 was caused by a multiconcurrency error in ffmpeg - it was failing while trying to decode bigger videos simultaneously - leading to crash of the resource microservice - which was a result of 503 errors while getting thumbnails. There is no way to correct it via configuration of ffmpeg - so decode requests have been serialized at the FastAPI level - by creating the endpoint responsible for returning thumbnails for video - an async endpoint. Such configuration - in case if the logic behind it is not asynchronous - leads to serializing execution of this endpoint.
By this occasion I increased the requests for CPU - to limit creation of new instances of resource ms.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Check if the issue #945 doesn't occur anymore.

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
