### PR TITLE
handling pat requests while returning workspaces

### DIFF
--- a/platform/services/account/app/grpc/utils/headers.go
+++ b/platform/services/account/app/grpc/utils/headers.go
@@ -99,6 +99,7 @@ func GetExternalTokenHeaderData(ctx context.Context) (*ExternalTokenData, bool) 
 
 func GetAuthTokenHeaderData(ctx context.Context) (*AuthTokenData, bool) {
 	tokenStr, ok := GetHTTPHeaderFromGRPCContext(ctx, "x-auth-request-access-token")
+
 	if !ok {
 		return nil, false
 	}
@@ -109,10 +110,16 @@ func GetAuthTokenHeaderData(ctx context.Context) (*AuthTokenData, bool) {
 		return nil, false
 	}
 
-	userId, ok := claims["preferred_username"].(string)
+	/* Handle requests coming with Personal Access Tokens - where user id is in owner_id field*/
+	userId, ok := claims["owner_id"].(string)
+
 	if !ok {
-		logger.Warn("user ID missing in JWT claims")
-		return nil, false
+	    userId, ok = claims["preferred_username"].(string)
+
+        if !ok {
+            logger.Warn("user ID missing in JWT claims")
+            return nil, false
+        }
 	}
 
 	orgId, ok := claims["organization_id"].(string)


### PR DESCRIPTION
## 📝 Description

Allows to use personal access token to authorize calls to endpoint returning a list of workspaces.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [x] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Check if the GET ../workspaces endpoint can be called using both - personal access token and access token used by UI.

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
