### PR TITLE
handling cases when a logged user is workspace admin and organization admin at once

### DIFF
--- a/platform/services/account/app/grpc/common/roles_filters.go
+++ b/platform/services/account/app/grpc/common/roles_filters.go
@@ -77,6 +77,7 @@ func FilterRolesByCurrentUserPermissions(currentUserID string, rolesToFilter []*
 	currentUserRoles := RelationshipsToUserRoles(currentUserRelationships)
 
 	for _, role := range rolesToFilter {
+
 		roleResourceType := role.GetResourceType()
 
 		if roleResourceType == "workspace" || roleResourceType == "organization" {
@@ -104,10 +105,6 @@ func FilterRolesByCurrentUserPermissions(currentUserID string, rolesToFilter []*
 				continue
 			}
 
-			if HasRole(currentUserRoles, "workspace_admin", []string{"workspace"}, parentWorkspaceID) {
-				filteredRoles = append(filteredRoles, role)
-			}
-
 			parentOrganizationID, err := rolesMgr.GetWorkspaceParentOrganizationID(parentWorkspaceID)
 			if err != nil {
 				logger.Errorf("unable to get parent organization for the workspace %s: %v", parentWorkspaceID, err)
@@ -116,7 +113,13 @@ func FilterRolesByCurrentUserPermissions(currentUserID string, rolesToFilter []*
 
 			if HasRole(currentUserRoles, "organization_admin", []string{"organization"}, parentOrganizationID) {
 				filteredRoles = append(filteredRoles, role)
+				continue
 			}
+
+			if HasRole(currentUserRoles, "workspace_admin", []string{"workspace"}, parentWorkspaceID) {
+				filteredRoles = append(filteredRoles, role)
+			}
+
 		}
 	}
 


### PR DESCRIPTION
## 📝 Description

When a user who was logged in was an organization admin and workspace admin and was not a part of a certain project - endpoint responsible for returning users' data with their roles was returning duplicate roles at the project level. To correct it I modified the order in which roles were checked - starting now from the most important one.

- Fixes #1275

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

As described in the #1275

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
