### PR TITLE
handling filtering based on resource type only

### DIFF
--- a/platform/services/account/app/grpc/user/find.go
+++ b/platform/services/account/app/grpc/user/find.go
@@ -280,7 +280,9 @@ func filterUserRoles(ctx context.Context, userData *pb.UserData, userRolesMap Us
 		if isAuthTokenPresent {
 			logger.Debug("auth token present, filtering by permissions...")
 			var err error
+			logger.Debugf("1 - Returning filtered roles %v for user %v", filteredRoles, authTokenData.UserID)
 			filteredRoles, err = common.FilterRolesByCurrentUserPermissions(authTokenData.UserID, filteredRoles)
+			logger.Debugf("2 - Returning filtered roles %v for user %v", filteredRoles, authTokenData.UserID)
 			if err != nil {
 				logger.Errorf("error during filtering roles: %v", err)
 				return status.Errorf(codes.Unknown, "unexpected error")
@@ -365,7 +367,7 @@ func (s *GRPCServer) Find(ctx context.Context, findRequest *pb.FindUserRequest) 
 		return nil, err
 	}
 
-	if len(findRequest.ResourceType) > 0 || findRequest.Role != "" || findRequest.ResourceId != "" {
+	if (len(findRequest.ResourceType) > 0 && findRequest.ResourceId != "") || findRequest.Role != "" {
 		users = filterUsersByRole(findRequest, users, userRolesMap)
 		response.TotalMatchedCount = int32(len(users))
 	}

--- a/platform/services/account/app/grpc/user/find.go
+++ b/platform/services/account/app/grpc/user/find.go
@@ -280,9 +280,7 @@ func filterUserRoles(ctx context.Context, userData *pb.UserData, userRolesMap Us
 		if isAuthTokenPresent {
 			logger.Debug("auth token present, filtering by permissions...")
 			var err error
-			logger.Debugf("1 - Returning filtered roles %v for user %v", filteredRoles, authTokenData.UserID)
 			filteredRoles, err = common.FilterRolesByCurrentUserPermissions(authTokenData.UserID, filteredRoles)
-			logger.Debugf("2 - Returning filtered roles %v for user %v", filteredRoles, authTokenData.UserID)
 			if err != nil {
 				logger.Errorf("error during filtering roles: %v", err)
 				return status.Errorf(codes.Unknown, "unexpected error")


### PR DESCRIPTION
## 📝 Description

Currently - filtering a list of users based on resourceType only includes also id of a workspaces that belongs to a caller of this endpoint. Within this PR I removed this additional filtering - resolving the issue found during diagnosis of the #1274.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Check if on environments with support for multi workspaces a list of users for "All workspaces" contains the same users as when you choose any certain workspace.

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
