### PR TITLE
Enable account service for helm deployments

### DIFF
--- a/deploy/charts/control-plane/chart/values.yaml
+++ b/deploy/charts/control-plane/chart/values.yaml
@@ -45,7 +45,7 @@ global:
     allow_credentials: true
 
 enabled:
-  account-service: false
+  account-service: true
   onboarding-service: false
   notifier: false
   credit-system: false


### PR DESCRIPTION
Confirmed that both standard installation, and helm deployment do work.