### PR TITLE
chore(ci): pin Debian in `collect-source.yml`

### DIFF
--- a/.github/workflows/collect-source.yml
+++ b/.github/workflows/collect-source.yml
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: get-unique-names
     container:
-      image: debian:12.8
+      image: debian:bookworm-slim@sha256:df52e55e3361a81ac1bead266f3373ee55d29aa50cf0975d440c2be3483d8ed3
     steps:
     - name: Add apt sources for deb-src
       shell: bash


### PR DESCRIPTION
## 📝 Description

This PR aligns Debian version used in `collect-source.yml` with version used in Dockerfiles and also prevents Renovate to upgrading it ([see this PR](https://github.com/open-edge-platform/geti/pull/1304/files#diff-9413fa342b22c27e46b2d415c75bf9db09affb1c22f2b775552fa748aaf8bbaf)).

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually: was tested in fork - https://github.com/AlexanderBarabanov/geti/actions/runs/17804890014
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
