### PR TITLE
ci(fix): separate Renovate PRs for `dev_tools/builder_images`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,6 +63,18 @@
       schedule: ["* * * * 0"], // weekly
     },
 
+    // Base images from dev_tools/builder_images
+    // are upgraded separately as it requires two steps
+    {
+      enabled: true,
+      matchDatasources: ["docker"],
+      pinDigests: true,
+      groupName: "Pin builder images",
+      groupSlug: "pin-builders",
+      schedule: ["* * 1 * *"], // every month
+      matchPaths: ["dev_tools/builder_images/**"],
+    },
+
     // Disable non-security upgrades for go and npm.
     // We will enable it in the next phase
     {


### PR DESCRIPTION
## 📝 Description

This PR updates the Renovate configuration and separates PRs with base images in the `dev_tools/builder_images` folder, as such PRs require two steps.

Expected behavior:
https://github.com/AlexanderBarabanov/geti/pulls
- https://github.com/AlexanderBarabanov/geti/pull/4
- https://github.com/AlexanderBarabanov/geti/pull/5
## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [x] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
