### PR TITLE
removal of workspace admin privileges for org admins when multiworkspace enabled

### DIFF
--- a/platform/services/account/app/config/env.go
+++ b/platform/services/account/app/config/env.go
@@ -169,5 +169,5 @@ var (
 	FeatureFlagAccSvcMod        = utils.GetBoolEnvOrDefault(featureFlagAccSvcMod, featureFlagDefaultValue)
 	FeatureFlagReqAccess        = utils.GetBoolEnvOrDefault(featureFlagReqAccess, featureFlagDefaultValue)
 
-    FeatureFlagWorkspaceActions = utils.GetBoolEnvOrDefault(featureFlagWorkspaceActions, featureFlagDefaultValue)
+	FeatureFlagWorkspaceActions = utils.GetBoolEnvOrDefault(featureFlagWorkspaceActions, featureFlagDefaultValue)
 )

--- a/platform/services/account/app/config/env.go
+++ b/platform/services/account/app/config/env.go
@@ -89,6 +89,8 @@ const (
 	featureFlagManageUsersRoles = "FEATURE_FLAG_MANAGE_USERS_ROLES"
 	featureFlagAccSvcMod        = "FEATURE_FLAG_ACC_SVC_MOD"
 	featureFlagReqAccess        = "FEATURE_FLAG_REQ_ACCESS"
+
+    featureFlagWorkspaceActions = "FEATURE_FLAG_WORKSPACE_ACTIONS"
 )
 
 //goland:noinspection GoCommentStart
@@ -166,4 +168,6 @@ var (
 	FeatureFlagManageUsersRoles = utils.GetBoolEnvOrDefault(featureFlagManageUsersRoles, featureFlagDefaultValue)
 	FeatureFlagAccSvcMod        = utils.GetBoolEnvOrDefault(featureFlagAccSvcMod, featureFlagDefaultValue)
 	FeatureFlagReqAccess        = utils.GetBoolEnvOrDefault(featureFlagReqAccess, featureFlagDefaultValue)
+
+    FeatureFlagWorkspaceActions = utils.GetBoolEnvOrDefault(featureFlagWorkspaceActions, featureFlagDefaultValue)
 )

--- a/platform/services/account/app/migration/migration.go
+++ b/platform/services/account/app/migration/migration.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+package migration
+
+import (
+    "account_service/app/common/utils"
+	"account_service/app/config"
+	"account_service/app/roles"
+
+    v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+)
+
+var logger = utils.InitializeLogger()
+
+// MigrateUsers performs user data migration tasks.
+// As it is executed every time the service starts, ensure idempotency.
+func MigrateUsers() {
+    logger.Info("User data migration tasks - start")
+    if config.FeatureFlagWorkspaceActions {
+        RemoveWorkspaceAdminsForOrgAdmins()
+    }
+    logger.Info("User data migration tasks - stop")
+}
+
+// RemoveWorkspaceAdminsForOrgAdmins removes all superfluous workspace admin roles for users
+// who are already organization admins. Executed only if the FeatureFlagWorkspaceActions is enabled
+func RemoveWorkspaceAdminsForOrgAdmins() {
+    logger.Info("Removal of workspace admins for org admins - start")
+    rolesMgr, err := roles.NewRolesManager(config.SpiceDBAddress, config.SpiceDBToken)
+
+	if err != nil {
+		logger.Errorf("Removal of workspace admins for org admins - unable to get roles manager: %v", err)
+		return
+	}
+
+	orgAdminsFilter := v1.RelationshipFilter{
+		ResourceType:       "organization",
+		OptionalRelation:   "organization_admin",
+	}
+
+	orgAdminsList, err := rolesMgr.GetRelationships(&orgAdminsFilter)
+
+	if err != nil {
+		logger.Errorf("Removal of workspace admins for org admins - unable to get list of org admins: %v", err)
+		return
+	}
+
+    for _, orgRelationship := range orgAdminsList {
+        userID := orgRelationship.Subject.Object.ObjectId
+        // Get workspace_admin relationship for a given user
+        workspaceAdminsFilter := v1.RelationshipFilter{
+            OptionalSubjectFilter: &v1.SubjectFilter{
+                SubjectType:       "user",
+                OptionalSubjectId: userID,
+            },
+            OptionalRelation:   "workspace_admin",
+        }
+
+        workspaceAdminsList, err := rolesMgr.GetRelationships(&workspaceAdminsFilter)
+        if err != nil {
+            logger.Errorf("Removal of workspace admins for org admins - unable to get list of workspace admins for user %s: %v", userID, err)
+            continue
+        }
+
+        for _, relationship := range workspaceAdminsList {
+
+            err := rolesMgr.ChangeUserRelation("workspace",
+                   relationship.Resource.ObjectId, []string{"workspace_admin"}, relationship.Subject.Object.ObjectId,
+                   v1.RelationshipUpdate_OPERATION_DELETE)
+
+            if err != nil {
+                logger.Errorf("Removal of workspace admins for org admins - unable to remove workspace_admin role for user %s: %v", userID, err)
+            }
+        }
+	}
+
+    logger.Info("Removal of workspace admins for org admins - stop")
+}

--- a/platform/services/account/app/migration/migration.go
+++ b/platform/services/account/app/migration/migration.go
@@ -8,7 +8,7 @@ import (
 	"account_service/app/config"
 	"account_service/app/roles"
 
-    v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 )
 
 var logger = utils.InitializeLogger()

--- a/platform/services/account/main.go
+++ b/platform/services/account/main.go
@@ -22,6 +22,7 @@ import (
 	"account_service/app/grpc/user_settings"
 	"account_service/app/grpc/workspace"
 	"account_service/app/grpc_gateway"
+	"account_service/app/migration"
 	"account_service/app/models"
 	"account_service/app/repository"
 	"account_service/app/rest"
@@ -253,6 +254,8 @@ func main() {
 	}(conn)
 
 	initSpiceDB()
+
+    migration.MigrateUsers()
 
 	go runGRPCServer(db)
 	if config.OtelEnableMetrics {


### PR DESCRIPTION
## 📝 Description

PR adds a step responsible for migration organization admins roles - when upgrading to a version with multiworkspace support enabled. In such case - organization admins shouldn't have workspace admin roles - as they are superfluous (org admin already has all privileges related to workspace admins) and their presence may lead to inconsistency in displaying user's data.

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [x] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Check if during upgrade to a version with multiworkspace support enabled - all workspace admin roles are removed for organization admins. Check also - if without this support - workspace admin roles remain untouched.

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
