### PR TITLE
Change multiple workspaces tabs into picker when too many workspaces to display

### DIFF
--- a/web_ui/src/pages/landing-page/workspaces-tabs/workspaces-tabs.component.tsx
+++ b/web_ui/src/pages/landing-page/workspaces-tabs/workspaces-tabs.component.tsx
@@ -53,18 +53,17 @@ export const WorkspacesTabs = () => {
     };
 
     return (
-        <Flex id={`page-layout-id`} direction='column' height='100%' UNSAFE_className={classes.componentWrapper}>
+        <Flex id={`page-layout-id`} direction='column' height='100%'>
             <Tabs
                 selectedKey={selectedWorkspaceId}
                 items={items}
                 aria-label={'Workspaces tabs'}
                 height={'100%'}
                 width={'100%'}
-                orientation={'vertical'}
                 onSelectionChange={handleSelectWorkspace}
             >
                 <Flex width={'100%'} alignItems={'center'} UNSAFE_className={classes.tabWrapper}>
-                    <TabList UNSAFE_className={classes.tabList}>
+                    <TabList UNSAFE_className={classes.tabList} width={'100%'}>
                         {(item: TabItem) => (
                             <Item textValue={item.name as string} key={item.key}>
                                 <>

--- a/web_ui/src/pages/landing-page/workspaces-tabs/workspaces-tabs.component.tsx
+++ b/web_ui/src/pages/landing-page/workspaces-tabs/workspaces-tabs.component.tsx
@@ -4,7 +4,7 @@
 import { useFeatureFlags } from '@geti/core/src/feature-flags/hooks/use-feature-flags.hook';
 import { useWorkspacesApi } from '@geti/core/src/workspaces/hooks/use-workspaces.hook';
 import { WorkspaceEntity } from '@geti/core/src/workspaces/services/workspaces.interface';
-import { ActionButton, Flex, Item, Loading, TabList, TabPanels, Tabs, Tooltip, TooltipTrigger } from '@geti/ui';
+import { ActionButton, Flex, Item, Loading, TabList, TabPanels, Tabs, Tooltip, TooltipTrigger, View } from '@geti/ui';
 import { Add } from '@geti/ui/icons';
 
 import { useOrganizationIdentifier } from '../../../hooks/use-organization-identifier/use-organization-identifier.hook';
@@ -66,31 +66,28 @@ export const WorkspacesTabs = () => {
                     <TabList UNSAFE_className={classes.tabList} width={'100%'}>
                         {(item: TabItem) => (
                             <Item textValue={item.name as string} key={item.key}>
-                                <>
-                                    <Flex alignItems={'center'}>
-                                        {selectedWorkspaceId === item.key && FEATURE_FLAG_WORKSPACE_ACTIONS ? (
-                                            <HasPermission
-                                                operations={[OPERATION.WORKSPACE_MANAGEMENT]}
-                                                specialCondition={true}
-                                                Fallback={
-                                                    <CustomTabItem
-                                                        name={item.name as string}
-                                                        isMoreIconVisible={false}
-                                                    />
-                                                }
-                                            >
-                                                <CustomTabItemWithMenu
-                                                    workspace={selectedWorkspace as WorkspaceEntity}
-                                                    isMoreIconVisible={item.key === selectedWorkspaceId}
-                                                    workspaces={workspaces}
-                                                    selectWorkspace={selectWorkspace}
-                                                />
-                                            </HasPermission>
-                                        ) : (
-                                            <CustomTabItem name={item.name as string} isMoreIconVisible={false} />
-                                        )}
-                                    </Flex>
-                                </>
+                                {selectedWorkspaceId === item.key && FEATURE_FLAG_WORKSPACE_ACTIONS ? (
+                                    <View marginTop={'size-65'}>
+                                        <HasPermission
+                                            operations={[OPERATION.WORKSPACE_MANAGEMENT]}
+                                            specialCondition={true}
+                                            Fallback={
+                                                <CustomTabItem name={item.name as string} isMoreIconVisible={false} />
+                                            }
+                                        >
+                                            <CustomTabItemWithMenu
+                                                workspace={selectedWorkspace as WorkspaceEntity}
+                                                isMoreIconVisible={item.key === selectedWorkspaceId}
+                                                workspaces={workspaces}
+                                                selectWorkspace={selectWorkspace}
+                                            />
+                                        </HasPermission>
+                                    </View>
+                                ) : (
+                                    <View>
+                                        <CustomTabItem name={item.name as string} isMoreIconVisible={false} />
+                                    </View>
+                                )}
                             </Item>
                         )}
                     </TabList>

--- a/web_ui/src/pages/user-management/workspaces/workspace-users-toolbar.component.tsx
+++ b/web_ui/src/pages/user-management/workspaces/workspace-users-toolbar.component.tsx
@@ -1,0 +1,152 @@
+// Copyright (C) 2022-2025 Intel Corporation
+// LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
+
+import { Key } from 'react';
+
+import { useFeatureFlags } from '@geti/core/src/feature-flags/hooks/use-feature-flags.hook';
+import { useActiveUser } from '@geti/core/src/users/hook/use-users.hook';
+import { isOrganizationAdmin } from '@geti/core/src/users/user-role-utils';
+import { RESOURCE_TYPE } from '@geti/core/src/users/users.interface';
+import { useWorkspacesApi } from '@geti/core/src/workspaces/hooks/use-workspaces.hook';
+import { WorkspaceEntity } from '@geti/core/src/workspaces/services/workspaces.interface';
+import { ActionButton, Flex, Item, Loading, TabList, Tabs, Tooltip, TooltipTrigger, View } from '@geti/ui';
+import { Add } from '@geti/ui/icons';
+
+import { useOrganizationIdentifier } from '../../../hooks/use-organization-identifier/use-organization-identifier.hook';
+import { CustomTabItem } from '../../../shared/components/custom-tab-item/custom-tab-item.component';
+import { EditNameDialog } from '../../../shared/components/edit-name-dialog/edit-name-dialog.component';
+import { HasPermission } from '../../../shared/components/has-permission/has-permission.component';
+import { OPERATION } from '../../../shared/components/has-permission/has-permission.interface';
+import { getUniqueNameFromArray } from '../../../shared/utils';
+import { WorkspaceDeleteDialog } from '../../landing-page/workspaces-tabs/components/workspace-delete-dialog.component';
+import { CustomTabItemWithMenu } from '../../landing-page/workspaces-tabs/custom-tab-item-with-menu.component';
+import { useWorkspaceActions } from '../../landing-page/workspaces-tabs/hooks/use-workspace-actions.hook';
+
+interface WorkspaceUsersToolbarProps {
+    workspaces: WorkspaceEntity[];
+    selectedWorkspaceId: string | undefined;
+    onSelectWorkspace: (id: string) => void;
+}
+
+export const WorkspaceUsersToolbar = ({
+    workspaces,
+    selectedWorkspaceId,
+    onSelectWorkspace,
+}: WorkspaceUsersToolbarProps) => {
+    const { organizationId } = useOrganizationIdentifier();
+    const { data: activeUser } = useActiveUser(organizationId);
+    const { useCreateWorkspaceMutation } = useWorkspacesApi(organizationId);
+    const createWorkspace = useCreateWorkspaceMutation();
+
+    const { FEATURE_FLAG_WORKSPACE_ACTIONS } = useFeatureFlags();
+
+    const selectedWorkspace = workspaces.find((w) => w.id === selectedWorkspaceId);
+
+    const { deleteDialog, editDialog } = useWorkspaceActions(workspaces.length, selectedWorkspaceId);
+
+    const tabItems = workspaces.map((w) => ({ key: w.id, name: w.name }));
+
+    const handleSelection = (key: Key) => {
+        onSelectWorkspace(key.toString());
+    };
+
+    const handleCreateWorkspace = () => {
+        const unique = getUniqueNameFromArray(
+            workspaces.map((w) => w.name),
+            'Workspace '
+        );
+        createWorkspace.mutate({ name: unique });
+    };
+
+    return (
+        <Flex direction={'column'} gap={'size-150'}>
+            <Tabs
+                selectedKey={selectedWorkspaceId}
+                onSelectionChange={handleSelection}
+                aria-label={'Workspace tabs'}
+                items={tabItems}
+            >
+                <Flex alignItems={'center'} gap={'size-200'} UNSAFE_style={{ overflow: 'hidden' }}>
+                    <TabList width={'100%'}>
+                        {(item: { key: string; name: string }) => {
+                            return (
+                                <Item key={item.key} textValue={item.name}>
+                                    {item.key === selectedWorkspaceId && FEATURE_FLAG_WORKSPACE_ACTIONS ? (
+                                        <View>
+                                            <HasPermission
+                                                operations={[OPERATION.WORKSPACE_MANAGEMENT]}
+                                                resources={[{ type: RESOURCE_TYPE.WORKSPACE, id: item.key }]}
+                                                specialCondition={
+                                                    activeUser !== undefined &&
+                                                    isOrganizationAdmin(activeUser, organizationId)
+                                                }
+                                                Fallback={<CustomTabItem name={item.name} isMoreIconVisible={false} />}
+                                            >
+                                                <View marginTop={'size-65'}>
+                                                    <CustomTabItemWithMenu
+                                                        workspace={selectedWorkspace as WorkspaceEntity}
+                                                        isMoreIconVisible={item.key === selectedWorkspaceId}
+                                                        workspaces={workspaces}
+                                                        selectWorkspace={(id: string) => handleSelection(id)}
+                                                    />
+                                                </View>
+                                            </HasPermission>
+                                        </View>
+                                    ) : (
+                                        <CustomTabItem isMoreIconVisible={false} name={item.name} />
+                                    )}
+                                </Item>
+                            );
+                        }}
+                    </TabList>
+                    {FEATURE_FLAG_WORKSPACE_ACTIONS && (
+                        <HasPermission operations={[OPERATION.WORKSPACE_CREATION]}>
+                            <TooltipTrigger placement={'bottom'}>
+                                <ActionButton
+                                    isQuiet
+                                    aria-label={'Create workspace'}
+                                    id={'create-workspace-toolbar-btn'}
+                                    onPress={handleCreateWorkspace}
+                                    isDisabled={createWorkspace.isPending}
+                                >
+                                    {createWorkspace.isPending ? <Loading mode='inline' size={'S'} /> : <Add />}
+                                </ActionButton>
+                                <Tooltip>Create workspace</Tooltip>
+                            </TooltipTrigger>
+                        </HasPermission>
+                    )}
+                </Flex>
+            </Tabs>
+            {/* Dialogs for selected workspace */}
+            {selectedWorkspace && deleteDialog.deleteWorkspaceDialogState.isOpen && (
+                <WorkspaceDeleteDialog
+                    name={selectedWorkspace.name}
+                    onAction={() => {
+                        deleteDialog.deleteWorkspaceMutation.mutate(
+                            { id: selectedWorkspace.id },
+                            { onSuccess: () => deleteDialog.deleteWorkspaceDialogState.close() }
+                        );
+                    }}
+                    triggerState={deleteDialog.deleteWorkspaceDialogState}
+                    workspaceId={selectedWorkspace.id}
+                />
+            )}
+            {selectedWorkspace && editDialog.editWorkspaceDialogState.isOpen && (
+                <EditNameDialog
+                    isLoading={editDialog.editWorkspaceMutation.isPending}
+                    triggerState={editDialog.editWorkspaceDialogState}
+                    onAction={(newName) =>
+                        editDialog.editWorkspaceMutation.mutate(
+                            { ...selectedWorkspace, name: newName },
+                            { onSuccess: () => editDialog.editWorkspaceDialogState.close() }
+                        )
+                    }
+                    defaultName={selectedWorkspace.name}
+                    names={workspaces.map((w) => w.name).filter((n) => n !== selectedWorkspace.name)}
+                    title={'workspace name'}
+                    nameLimitations={{ maxLength: 64, minLength: 1 }}
+                />
+            )}
+        </Flex>
+    );
+};

--- a/web_ui/src/pages/user-management/workspaces/workspace-users-toolbar.component.tsx
+++ b/web_ui/src/pages/user-management/workspaces/workspace-users-toolbar.component.tsx
@@ -72,7 +72,7 @@ export const WorkspaceUsersToolbar = ({
                             return (
                                 <Item key={item.key} textValue={item.name}>
                                     {item.key === selectedWorkspaceId && FEATURE_FLAG_WORKSPACE_ACTIONS ? (
-                                        <View>
+                                        <View marginTop={'size-65'}>
                                             <HasPermission
                                                 operations={[OPERATION.WORKSPACE_MANAGEMENT]}
                                                 resources={[{ type: RESOURCE_TYPE.WORKSPACE, id: item.key }]}
@@ -82,18 +82,18 @@ export const WorkspaceUsersToolbar = ({
                                                 }
                                                 Fallback={<CustomTabItem name={item.name} isMoreIconVisible={false} />}
                                             >
-                                                <View marginTop={'size-65'}>
-                                                    <CustomTabItemWithMenu
-                                                        workspace={selectedWorkspace as WorkspaceEntity}
-                                                        isMoreIconVisible={item.key === selectedWorkspaceId}
-                                                        workspaces={workspaces}
-                                                        selectWorkspace={(id: string) => handleSelection(id)}
-                                                    />
-                                                </View>
+                                                <CustomTabItemWithMenu
+                                                    workspace={selectedWorkspace as WorkspaceEntity}
+                                                    isMoreIconVisible={item.key === selectedWorkspaceId}
+                                                    workspaces={workspaces}
+                                                    selectWorkspace={(id: string) => handleSelection(id)}
+                                                />
                                             </HasPermission>
                                         </View>
                                     ) : (
-                                        <CustomTabItem isMoreIconVisible={false} name={item.name} />
+                                        <View>
+                                            <CustomTabItem isMoreIconVisible={false} name={item.name} />
+                                        </View>
                                     )}
                                 </Item>
                             );

--- a/web_ui/src/shared/components/custom-tab-item/custom-tab-item.module.scss
+++ b/web_ui/src/shared/components/custom-tab-item/custom-tab-item.module.scss
@@ -9,6 +9,7 @@
 }
 
 .customTabItemMenuTrigger {
+    height: inherit !important;
     border: none !important;
 
     &:hover,

--- a/web_ui/src/shared/components/custom-tab-item/custom-tab-item.module.scss
+++ b/web_ui/src/shared/components/custom-tab-item/custom-tab-item.module.scss
@@ -100,5 +100,5 @@
     border-bottom: var(--spectrum-global-dimension-size-10) solid
         var(--spectrum-tabs-rule-color, var(--spectrum-global-color-gray-200)) !important;
     box-sizing: border-box !important;
-    overflow-x: auto;
+    overflow: hidden;
 }


### PR DESCRIPTION
## 📝 Description

- Fix aimed to change multiple workspaces tabs into picker when too many workspaces to display instead of adding scroll

Before:
<img width="1138" height="424" alt="Screenshot 2025-10-09 at 10 10 34" src="https://github.com/user-attachments/assets/80ff7842-1f9c-4f89-958e-94cc2c5b28ec" />

After:
<img width="1307" height="486" alt="Screenshot 2025-10-13 at 08 34 53" src="https://github.com/user-attachments/assets/417e211b-5940-4155-9b9f-62f9438d06be" />




- Fix display of Picker items as shown below

Before:
<img width="1138" height="495" alt="Screenshot 2025-10-09 at 11 12 56" src="https://github.com/user-attachments/assets/daa69e4b-2995-47cb-b842-b0da61e0c6d6" />

After:
<img width="1138" height="495" alt="Screenshot 2025-10-09 at 11 12 09" src="https://github.com/user-attachments/assets/d9554a98-1c27-4377-b7e4-1ad95c49017a" />

Environment to check: https://10.55.252.10/

Since `workspace-users-toolbar.component.tsx`  hasn't been implemented on main branch yet please withhold with reviewing it YET :)


## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update** 
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
