### PR TITLE
Correction of checking of a presence of Intel GPU

### DIFF
--- a/platform/services/installer/app/checks/resources.py
+++ b/platform/services/installer/app/checks/resources.py
@@ -189,7 +189,7 @@ def _get_intel_gpus() -> str:
         logger.debug(f"Getting the list of Intel ARC with {command}")
 
         env = os.environ.copy()
-        env.pop('LD_LIBRARY_PATH', None)
+        env.pop("LD_LIBRARY_PATH", None)
 
         clinfo_output = subprocess.check_output(  # noqa: S602  # nosec: B602
             command,

--- a/platform/services/installer/app/checks/resources.py
+++ b/platform/services/installer/app/checks/resources.py
@@ -187,11 +187,16 @@ def _get_intel_gpus() -> str:
     try:
         command = 'clinfo|grep "' + ResourcesChecksTexts.intel_gpu_arc_device_name + '"|grep Intel'
         logger.debug(f"Getting the list of Intel ARC with {command}")
+
+        env = os.environ.copy()
+        env.pop('LD_LIBRARY_PATH', None)
+
         clinfo_output = subprocess.check_output(  # noqa: S602  # nosec: B602
             command,
             stderr=subprocess.STDOUT,
             shell=True,
             timeout=5,
+            env=env,
         ).decode("utf-8")
         logger.debug(clinfo_output)
         if ResourcesChecksTexts.intel_gpu_arc_device_name in clinfo_output:

--- a/platform/services/installer/app/checks/resources.py
+++ b/platform/services/installer/app/checks/resources.py
@@ -169,10 +169,16 @@ def _get_intel_gpus() -> str:
     ARC cards:
     We rely on the output of clinfo
     """
+    # pyinstaller sets the LD_LIBRARY_PATH env variable value to a folder with unpacked dependencies
+    # which contains the libstdc++.so.6 library - this library causes errors while executing clinfo/xpu-smi.
+    # I remove then this variable from env passed to clinfo - to get rid of this error.
+    env = os.environ.copy()
+    env.pop("LD_LIBRARY_PATH", None)
+
     # Only valid for MAX cards
     try:
         logger.debug("Getting the list of Intel GPU with `xpu-smi discovery`")
-        xpu_output = subprocess.check_output(["xpu-smi", "discovery"], timeout=5).decode("utf-8")  # noqa: S607
+        xpu_output = subprocess.check_output(["xpu-smi", "discovery"], timeout=5, env=env).decode("utf-8")  # noqa: S607
         logger.debug(xpu_output)
         if ResourcesChecksTexts.intel_gpu_no_devices in xpu_output:
             logger.debug("No devices")
@@ -187,9 +193,6 @@ def _get_intel_gpus() -> str:
     try:
         command = 'clinfo|grep "' + ResourcesChecksTexts.intel_gpu_arc_device_name + '"|grep Intel'
         logger.debug(f"Getting the list of Intel ARC with {command}")
-
-        env = os.environ.copy()
-        env.pop("LD_LIBRARY_PATH", None)
 
         clinfo_output = subprocess.check_output(  # noqa: S602  # nosec: B602
             command,


### PR DESCRIPTION
## 📝 Description

- Fixes #1393
- Fixes #1390

Clearing the LD_LIBRARY_PATH for executing the clinfo command ensures that it uses system OpenCL ICDs so Intel ARC devices are detected reliably. Using its default value set by pyinstaller leads to error as it points out internal folder containing the libstdc++.so.6 library which causes issues while running clinfo.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Check if ARC Intel GPUs are detected properly.

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
