### PR TITLE
display workspace-related roles on a screen with list of workspace users

### DIFF
--- a/web_ui/src/pages/user-management/users/project-users/project-users.component.tsx
+++ b/web_ui/src/pages/user-management/users/project-users/project-users.component.tsx
@@ -47,7 +47,7 @@ export const ProjectUsers = () => {
                 resourceType={RESOURCE_TYPE.PROJECT}
                 resourceId={projectId}
                 ignoredColumns={ignoredColumns}
-                isProjectUsersTable
+                usersTableType={RESOURCE_TYPE.PROJECT}
                 UserActions={ProjectUserActions}
             />
         </PageLayout>

--- a/web_ui/src/pages/user-management/users/users-header.component.tsx
+++ b/web_ui/src/pages/user-management/users/users-header.component.tsx
@@ -17,6 +17,7 @@ interface WorkspaceUsersHeaderProps {
     hasFilterOptions: boolean;
     setUsersQueryParams: Dispatch<SetStateAction<UsersQueryParams>>;
     isProjectUsersTable?: boolean;
+    isWorkspaceUsersTable?: boolean;
     actionsSlot?: ReactNode;
 }
 
@@ -26,14 +27,17 @@ export const UsersHeader = ({
     hasFilterOptions,
     setUsersQueryParams,
     isProjectUsersTable = false,
+    isWorkspaceUsersTable = false,
     actionsSlot,
 }: WorkspaceUsersHeaderProps) => {
     const [searchInput, setSearchInput] = useState<string>('');
     const [roleFilter, setRoleFilter] = useState<USER_ROLE | undefined>();
 
-    const roles = isProjectUsersTable
+   const roles = isProjectUsersTable
         ? [USER_ROLE.PROJECT_MANAGER, USER_ROLE.PROJECT_CONTRIBUTOR]
-        : [USER_ROLE.WORKSPACE_ADMIN, USER_ROLE.WORKSPACE_CONTRIBUTOR];
+        : isWorkspaceUsersTable
+        ? [USER_ROLE.WORKSPACE_ADMIN, USER_ROLE.WORKSPACE_CONTRIBUTOR]
+        : [USER_ROLE.ORGANIZATION_ADMIN, USER_ROLE.ORGANIZATION_CONTRIBUTOR];
 
     const debouncedCallback = useDebouncedCallback((value: string) => {
         setUsersQueryParams((prevQueryParams) => {

--- a/web_ui/src/pages/user-management/users/users-header.component.tsx
+++ b/web_ui/src/pages/user-management/users/users-header.component.tsx
@@ -3,7 +3,7 @@
 
 import { Dispatch, ReactNode, SetStateAction, useState } from 'react';
 
-import { USER_ROLE, UsersQueryParams } from '@geti/core/src/users/users.interface';
+import { RESOURCE_TYPE, USER_ROLE, UsersQueryParams } from '@geti/core/src/users/users.interface';
 import { Flex, SearchField } from '@geti/ui';
 import { isEmpty } from 'lodash-es';
 
@@ -16,8 +16,7 @@ interface WorkspaceUsersHeaderProps {
     totalMatchedCount: number;
     hasFilterOptions: boolean;
     setUsersQueryParams: Dispatch<SetStateAction<UsersQueryParams>>;
-    isProjectUsersTable?: boolean;
-    isWorkspaceUsersTable?: boolean;
+    usersTableType?: RESOURCE_TYPE;
     actionsSlot?: ReactNode;
 }
 
@@ -26,18 +25,18 @@ export const UsersHeader = ({
     totalCount,
     hasFilterOptions,
     setUsersQueryParams,
-    isProjectUsersTable = false,
-    isWorkspaceUsersTable = false,
+    usersTableType = RESOURCE_TYPE.ORGANIZATION,
     actionsSlot,
 }: WorkspaceUsersHeaderProps) => {
     const [searchInput, setSearchInput] = useState<string>('');
     const [roleFilter, setRoleFilter] = useState<USER_ROLE | undefined>();
 
-   const roles = isProjectUsersTable
-        ? [USER_ROLE.PROJECT_MANAGER, USER_ROLE.PROJECT_CONTRIBUTOR]
-        : isWorkspaceUsersTable
-        ? [USER_ROLE.WORKSPACE_ADMIN, USER_ROLE.WORKSPACE_CONTRIBUTOR]
-        : [USER_ROLE.ORGANIZATION_ADMIN, USER_ROLE.ORGANIZATION_CONTRIBUTOR];
+    const roles =
+        usersTableType === RESOURCE_TYPE.PROJECT
+            ? [USER_ROLE.PROJECT_MANAGER, USER_ROLE.PROJECT_CONTRIBUTOR]
+            : usersTableType === RESOURCE_TYPE.WORKSPACE
+              ? [USER_ROLE.WORKSPACE_ADMIN, USER_ROLE.WORKSPACE_CONTRIBUTOR]
+              : [USER_ROLE.ORGANIZATION_ADMIN, USER_ROLE.ORGANIZATION_CONTRIBUTOR];
 
     const debouncedCallback = useDebouncedCallback((value: string) => {
         setUsersQueryParams((prevQueryParams) => {

--- a/web_ui/src/pages/user-management/users/users-table/users-table.component.tsx
+++ b/web_ui/src/pages/user-management/users/users-table/users-table.component.tsx
@@ -107,7 +107,11 @@ export const UsersTable = ({
                 width: 180,
                 isSortable: false,
                 component: (data: TableCellProps) => (
-                    <UserRoleCell {...data} resourceId={resourceId} isProjectUsersTable={usersTableType === RESOURCE_TYPE.PROJECT} />
+                    <UserRoleCell
+                        {...data}
+                        resourceId={resourceId}
+                        isProjectUsersTable={usersTableType === RESOURCE_TYPE.PROJECT}
+                    />
                 ),
             },
             {

--- a/web_ui/src/pages/user-management/users/users-table/users-table.component.tsx
+++ b/web_ui/src/pages/user-management/users/users-table/users-table.component.tsx
@@ -3,7 +3,7 @@
 
 import { Dispatch, ReactNode, SetStateAction, useMemo } from 'react';
 
-import { User, UsersQueryParams } from '@geti/core/src/users/users.interface';
+import { RESOURCE_TYPE, User, UsersQueryParams } from '@geti/core/src/users/users.interface';
 import { Cell, Column, Flex, Row, TableBody, TableHeader, TableView, View } from '@geti/ui';
 import { get, isEmpty } from 'lodash-es';
 
@@ -41,7 +41,7 @@ interface UsersTableProps {
     UserActions: (props: { activeUser: User; user: User; users: User[] }) => ReactNode;
     ignoredColumns?: USERS_TABLE_COLUMNS[];
     resourceId: string | undefined;
-    isProjectUsersTable?: boolean;
+    usersTableType?: RESOURCE_TYPE;
     tableId?: string;
 }
 
@@ -56,7 +56,7 @@ export const UsersTable = ({
     resourceId,
     isLoading,
     isFetchingNextPage,
-    isProjectUsersTable,
+    usersTableType,
     getNextPage,
     tableId,
 }: UsersTableProps) => {
@@ -107,7 +107,7 @@ export const UsersTable = ({
                 width: 180,
                 isSortable: false,
                 component: (data: TableCellProps) => (
-                    <UserRoleCell {...data} resourceId={resourceId} isProjectUsersTable={isProjectUsersTable} />
+                    <UserRoleCell {...data} resourceId={resourceId} isProjectUsersTable={usersTableType === RESOURCE_TYPE.PROJECT} />
                 ),
             },
             {

--- a/web_ui/src/pages/user-management/users/users-table/users-table.component.tsx
+++ b/web_ui/src/pages/user-management/users/users-table/users-table.component.tsx
@@ -43,6 +43,7 @@ interface UsersTableProps {
     resourceId: string | undefined;
     usersTableType?: RESOURCE_TYPE;
     tableId?: string;
+    usersTableType?: RESOURCE_TYPE;
 }
 
 export const UsersTable = ({

--- a/web_ui/src/pages/user-management/users/users-table/users-table.component.tsx
+++ b/web_ui/src/pages/user-management/users/users-table/users-table.component.tsx
@@ -43,7 +43,6 @@ interface UsersTableProps {
     resourceId: string | undefined;
     usersTableType?: RESOURCE_TYPE;
     tableId?: string;
-    usersTableType?: RESOURCE_TYPE;
 }
 
 export const UsersTable = ({
@@ -101,7 +100,7 @@ export const UsersTable = ({
             {
                 label: isEmpty(resourceId)
                     ? 'Organization role'
-                    : isProjectUsersTable
+                    : usersTableType === RESOURCE_TYPE.PROJECT
                       ? 'Project role'
                       : 'Workspace role',
                 dataKey: USERS_TABLE_COLUMNS.ROLES,
@@ -145,7 +144,7 @@ export const UsersTable = ({
         ];
 
         return tableColumns.filter(({ dataKey }) => !ignoredColumns.includes(dataKey as USERS_TABLE_COLUMNS));
-    }, [ignoredColumns, resourceId, UserActions, activeUser, isProjectUsersTable, users]);
+    }, [ignoredColumns, resourceId, UserActions, activeUser, usersTableType, users]);
 
     const [sortingOptions, sort] = useSortTable<UsersQueryParams>({
         queryOptions: usersQueryParams,

--- a/web_ui/src/pages/user-management/users/users.component.tsx
+++ b/web_ui/src/pages/user-management/users/users.component.tsx
@@ -29,6 +29,7 @@ interface UsersProps {
     UserActions?: ComponentProps<typeof UsersTable>['UserActions'];
     ignoredColumns?: ComponentProps<typeof UsersTable>['ignoredColumns'];
     isProjectUsersTable?: ComponentProps<typeof UsersTable>['isProjectUsersTable'];
+    isWorkspaceUsersTable?: ComponentProps<typeof UsersTable>['isWorkspaceUsersTable'];
 }
 
 const USERS_LIMIT = 20;
@@ -40,6 +41,7 @@ export const Users = ({
     UserActions = () => <></>,
     ignoredColumns = [],
     isProjectUsersTable = false,
+    isWorkspaceUsersTable = false,
 }: UsersProps) => {
     const { organizationId } = useOrganizationIdentifier();
     const { workspaceId: firstWorkspaceId } = useFirstWorkspaceIdentifier();
@@ -99,6 +101,7 @@ export const Users = ({
                     hasFilterOptions={hasFilters}
                     setUsersQueryParams={setUsersQueryParams}
                     isProjectUsersTable={isProjectUsersTable}
+                    isWorkspaceUsersTable={isWorkspaceUsersTable}
                     actionsSlot={actionsSlot}
                 />
                 <UsersTable
@@ -115,6 +118,7 @@ export const Users = ({
                     ignoredColumns={ignoredColumns}
                     resourceId={resourceId}
                     isProjectUsersTable={isProjectUsersTable}
+                    isWorkspaceUsersTable={isWorkspaceUsersTable}
                 />
                 {resourceType === RESOURCE_TYPE.WORKSPACE && resourceId !== undefined && (
                     <AvailableWorkspaceUsers workspaceId={resourceId} activeUser={activeUser} />

--- a/web_ui/src/pages/user-management/users/users.component.tsx
+++ b/web_ui/src/pages/user-management/users/users.component.tsx
@@ -114,14 +114,7 @@ export const Users = ({
                     UserActions={UserActions}
                     ignoredColumns={ignoredColumns}
                     resourceId={resourceId}
-<<<<<<< HEAD
-                    isProjectUsersTable={isProjectUsersTable}
-                    isWorkspaceUsersTable={isWorkspaceUsersTable}
-=======
-                    workspaces={workspaces}
                     usersTableType={usersTableType}
-                    organizationId={organizationId}
->>>>>>> 8747a567 (using one attribute to keep the type of the table)
                 />
                 {resourceType === RESOURCE_TYPE.WORKSPACE && resourceId !== undefined && (
                     <AvailableWorkspaceUsers workspaceId={resourceId} activeUser={activeUser} />

--- a/web_ui/src/pages/user-management/users/users.component.tsx
+++ b/web_ui/src/pages/user-management/users/users.component.tsx
@@ -28,8 +28,7 @@ interface UsersProps {
     resourceId: string | undefined;
     UserActions?: ComponentProps<typeof UsersTable>['UserActions'];
     ignoredColumns?: ComponentProps<typeof UsersTable>['ignoredColumns'];
-    isProjectUsersTable?: ComponentProps<typeof UsersTable>['isProjectUsersTable'];
-    isWorkspaceUsersTable?: ComponentProps<typeof UsersTable>['isWorkspaceUsersTable'];
+    usersTableType?: ComponentProps<typeof UsersTable>['usersTableType'];
 }
 
 const USERS_LIMIT = 20;
@@ -40,8 +39,7 @@ export const Users = ({
     activeUser,
     UserActions = () => <></>,
     ignoredColumns = [],
-    isProjectUsersTable = false,
-    isWorkspaceUsersTable = false,
+    usersTableType = RESOURCE_TYPE.ORGANIZATION,
 }: UsersProps) => {
     const { organizationId } = useOrganizationIdentifier();
     const { workspaceId: firstWorkspaceId } = useFirstWorkspaceIdentifier();
@@ -100,8 +98,7 @@ export const Users = ({
                     totalCount={totalCount}
                     hasFilterOptions={hasFilters}
                     setUsersQueryParams={setUsersQueryParams}
-                    isProjectUsersTable={isProjectUsersTable}
-                    isWorkspaceUsersTable={isWorkspaceUsersTable}
+                    usersTableType={usersTableType}
                     actionsSlot={actionsSlot}
                 />
                 <UsersTable
@@ -117,8 +114,14 @@ export const Users = ({
                     UserActions={UserActions}
                     ignoredColumns={ignoredColumns}
                     resourceId={resourceId}
+<<<<<<< HEAD
                     isProjectUsersTable={isProjectUsersTable}
                     isWorkspaceUsersTable={isWorkspaceUsersTable}
+=======
+                    workspaces={workspaces}
+                    usersTableType={usersTableType}
+                    organizationId={organizationId}
+>>>>>>> 8747a567 (using one attribute to keep the type of the table)
                 />
                 {resourceType === RESOURCE_TYPE.WORKSPACE && resourceId !== undefined && (
                     <AvailableWorkspaceUsers workspaceId={resourceId} activeUser={activeUser} />

--- a/web_ui/src/pages/user-management/users/workspace-users/available-workspace-users.component.tsx
+++ b/web_ui/src/pages/user-management/users/workspace-users/available-workspace-users.component.tsx
@@ -128,7 +128,7 @@ export const AvailableWorkspaceUsers = ({ workspaceId, activeUser }: AvailableWo
                             USERS_TABLE_COLUMNS.ROLES,
                         ]}
                         resourceId={workspaceId}
-                        usersTableType={'RESOURCE_TYPE.WORKSPACE'}
+                        usersTableType={RESOURCE_TYPE.WORKSPACE}
                     />
                 </View>
             </Flex>

--- a/web_ui/src/pages/user-management/users/workspace-users/available-workspace-users.component.tsx
+++ b/web_ui/src/pages/user-management/users/workspace-users/available-workspace-users.component.tsx
@@ -128,7 +128,7 @@ export const AvailableWorkspaceUsers = ({ workspaceId, activeUser }: AvailableWo
                             USERS_TABLE_COLUMNS.ROLES,
                         ]}
                         resourceId={workspaceId}
-                        isProjectUsersTable={false}
+                        usersTableType={'RESOURCE_TYPE.WORKSPACE'}
                     />
                 </View>
             </Flex>

--- a/web_ui/src/pages/user-management/users/workspace-users/workspace-users.component.tsx
+++ b/web_ui/src/pages/user-management/users/workspace-users/workspace-users.component.tsx
@@ -27,7 +27,7 @@ export const WorkspaceUsers = ({ activeUser, workspaceId }: WorkspaceUsersProps)
             resourceId={workspaceId}
             UserActions={Actions}
             ignoredColumns={isSaasEnv ? undefined : [USERS_TABLE_COLUMNS.LAST_LOGIN]}
-            isWorkspaceUsersTable={true}
+            usersTableType={RESOURCE_TYPE.WORKSPACE}
         />
     );
 };

--- a/web_ui/src/pages/user-management/users/workspace-users/workspace-users.component.tsx
+++ b/web_ui/src/pages/user-management/users/workspace-users/workspace-users.component.tsx
@@ -27,6 +27,7 @@ export const WorkspaceUsers = ({ activeUser, workspaceId }: WorkspaceUsersProps)
             resourceId={workspaceId}
             UserActions={Actions}
             ignoredColumns={isSaasEnv ? undefined : [USERS_TABLE_COLUMNS.LAST_LOGIN]}
+            isWorkspaceUsersTable={true}
         />
     );
 };


### PR DESCRIPTION
## 📝 Description

On a list of workspace users (visible if the multiworkspace support is enabled) - in a combo with available roles used to filter this list - only roles related to workspace are displayed.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Check if proper roles are displayed in the combo used to filter users - organization users (Account/Users), workspace users (Account/Workspaces) and project users (Project/Users)

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
