### PR TITLE
gha: Fix wrong sha

### DIFF
--- a/.github/workflows/package-distribution.yaml
+++ b/.github/workflows/package-distribution.yaml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload build artifacts
         if: ${{ inputs.publish_binaries }}
-        uses: actions/upload-artifact@vea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: platform_installer
           path: platform/services/installer/platform_installer.tar.gz


### PR DESCRIPTION
## 📝 Description

This PR fixes an incorrect SHA hash in the GitHub Actions workflow file for the upload-artifact action.

Corrected the SHA hash for actions/upload-artifact@v4.6.2 from an invalid hash starting with 'v' to the proper commit hash

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
