### PR TITLE
removing kafka statefulset before upgrade

### DIFF
--- a/platform/services/installer/app/platform_stages/steps/apply_minor_version_changes/remove_previous_k8s_objects.py
+++ b/platform/services/installer/app/platform_stages/steps/apply_minor_version_changes/remove_previous_k8s_objects.py
@@ -87,6 +87,8 @@ def _remove_stateful_set():
         try:
             logger.debug("Deleting etcd stateful set.")
             core_api.delete_namespaced_stateful_set(name="impt-etcd", namespace="impt")
+            logger.debug("Deleting kafka stateful set.")
+            core_api.delete_namespaced_stateful_set(name="impt-kafka", namespace="impt")
         except kubernetes.client.exceptions.ApiException as ex:
             if ex.status != 404:
                 logger.error("Error when accessing the Kubernetes API.", exc_info=True)


### PR DESCRIPTION
## 📝 Description

In the 2.13 version we have replaced the bitnami kafka image with its official counterpart - which led to modifying charts responsible for installing it. Unfortunately - scale of changes in a chart makes it impossible to just update it (helm doesn't allow to change all components of the manifest when upgrading statefulset) when upgrading platform. To resolve this issue - we remove the statefulset during upgrade - and install a new one.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Check if upgrade to the 2.13 version works.

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
