### PR TITLE
Fix 403 from organizations endpoint when retrieving users

### DIFF
--- a/web_ui/src/pages/user-management/user-management.component.tsx
+++ b/web_ui/src/pages/user-management/user-management.component.tsx
@@ -151,7 +151,7 @@ export const UserManagement = () => {
                 id: `${UserManagementTabs.USERS}-user-page`,
                 key: UserManagementTabs.USERS,
                 name: capitalize(UserManagementTabs.USERS),
-                children: <UsersTab activeUser={activeUser as User} />,
+                children: <UsersTab activeUser={activeUser as User} resourceId={organizationId} />,
             },
             {
                 id: `${UserManagementTabs.PERSONAL_ACCESS_TOKEN}-user-page`,

--- a/web_ui/src/pages/user-management/users/users-tab.component.tsx
+++ b/web_ui/src/pages/user-management/users/users-tab.component.tsx
@@ -4,17 +4,15 @@
 import { RESOURCE_TYPE, User } from '@geti/core/src/users/users.interface';
 import { Flex, Text } from '@geti/ui';
 
-import { useOrganization } from '../../../intel-admin-app/pages/organization/hooks/organization.hook';
 import { OrganizationUserActions } from './actions/organization-user-actions.component';
 import { Users } from './users.component';
 
 interface UsersTabProps {
     activeUser: User | undefined;
+    resourceId: string;
 }
 
-export const UsersTab = ({ activeUser }: UsersTabProps) => {
-    const { organizationId } = useOrganization();
-
+export const UsersTab = ({ activeUser, resourceId }: UsersTabProps) => {
     if (!activeUser) return <></>;
 
     return (
@@ -28,7 +26,7 @@ export const UsersTab = ({ activeUser }: UsersTabProps) => {
             <Users
                 activeUser={activeUser}
                 resourceType={RESOURCE_TYPE.ORGANIZATION}
-                resourceId={organizationId}
+                resourceId={resourceId}
                 UserActions={OrganizationUserActions}
             />
         </Flex>

--- a/web_ui/src/pages/user-management/users/users-tab.test.tsx
+++ b/web_ui/src/pages/user-management/users/users-tab.test.tsx
@@ -45,7 +45,7 @@ describe('UsersTab', () => {
                 platformUtilsService.getProductInfo = async () =>
                     Promise.resolve(getMockedProductInfo({ isSmtpDefined: false }));
 
-                await render(<UsersTab activeUser={adminUser} />, {
+                await render(<UsersTab activeUser={adminUser} resourceId='org-id' />, {
                     services: { platformUtilsService, usersService },
                 });
 
@@ -58,7 +58,7 @@ describe('UsersTab', () => {
                 platformUtilsService.getProductInfo = async () =>
                     Promise.resolve(getMockedProductInfo({ isSmtpDefined: true }));
 
-                await render(<UsersTab activeUser={adminUser} />, {
+                await render(<UsersTab activeUser={adminUser} resourceId='org-id' />, {
                     services: { platformUtilsService, usersService },
                 });
 
@@ -76,7 +76,7 @@ describe('UsersTab', () => {
                 platformUtilsService.getProductInfo = async () =>
                     Promise.resolve(getMockedProductInfo({ isSmtpDefined: false }));
 
-                await render(<UsersTab activeUser={contributorUser} />, {
+                await render(<UsersTab activeUser={contributorUser} resourceId='org-id' />, {
                     services: { platformUtilsService, usersService },
                 });
 
@@ -89,7 +89,7 @@ describe('UsersTab', () => {
                 platformUtilsService.getProductInfo = async () =>
                     Promise.resolve(getMockedProductInfo({ isSmtpDefined: true }));
 
-                await render(<UsersTab activeUser={contributorUser} />, {
+                await render(<UsersTab activeUser={contributorUser} resourceId='org-id' />, {
                     services: { platformUtilsService, usersService },
                 });
 
@@ -113,7 +113,7 @@ describe('UsersTab', () => {
                 platformUtilsService.getProductInfo = async () =>
                     Promise.resolve(getMockedProductInfo({ isSmtpDefined: false }));
 
-                await render(<UsersTab activeUser={adminUser} />, {
+                await render(<UsersTab activeUser={adminUser} resourceId='org-id' />, {
                     services: { platformUtilsService, usersService },
                 });
 
@@ -131,7 +131,7 @@ describe('UsersTab', () => {
                 platformUtilsService.getProductInfo = async () =>
                     Promise.resolve(getMockedProductInfo({ isSmtpDefined: true }));
 
-                await render(<UsersTab activeUser={contributorUser} />, {
+                await render(<UsersTab activeUser={contributorUser} resourceId='org-id' />, {
                     services: { platformUtilsService, usersService },
                 });
 


### PR DESCRIPTION
## 📝 Description

When retrieving organizations users there was an additional call made to organizations endpoint which resulted in 403 for some users. To avoid this issue the organization id is passed in props.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [x] 🔍 PR title is clear and meaningful
- [x] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
