### PR TITLE
Restarting jobs after revert of an upgrade operation

### DIFF
--- a/platform/services/installer/app/commands/upgrade.py
+++ b/platform/services/installer/app/commands/upgrade.py
@@ -354,7 +354,7 @@ def execute_upgrade(config: UpgradeConfig) -> None:  # noqa: PLR0915
         perform_k3s_upgrade(config)
 
     reset_custom_signal_handler(handler_state)
-
+    revert = False
     try:
         prepare_upgrade(config, current_platform_version, data_folder, location)
         perform_upgrade(config)
@@ -364,6 +364,7 @@ def execute_upgrade(config: UpgradeConfig) -> None:  # noqa: PLR0915
         click.secho("\n" + UpgradeCmdTexts.upgrade_failed, fg="red")
         click.secho("\nReverting to the previous state...", fg="yellow")
         rollback_platform(config, location, data_folder)
+        revert = True
         click.secho("\n" + UpgradeCmdTexts.revert_succeeded, fg="green")
         sys.exit(1)
     except PrepareUpgradeException:
@@ -371,6 +372,7 @@ def execute_upgrade(config: UpgradeConfig) -> None:  # noqa: PLR0915
         click.secho("\n" + UpgradeCmdTexts.preparation_failed, fg="red")
         click.secho("\nReverting to the previous state...", fg="yellow")
         rollback_platform(config, location, data_folder)
+        revert = True
         click.secho("\n" + UpgradeCmdTexts.revert_succeeded, fg="green")
         sys.exit(1)
     finally:
@@ -383,7 +385,7 @@ def execute_upgrade(config: UpgradeConfig) -> None:  # noqa: PLR0915
             shutil.rmtree(OFFLINE_TOOLS_DIR)
         try:
             with click_spinner.spinner():
-                restore_platform(config=config)
+                restore_platform(config=config, revert=revert)
         except Exception:
             logger.error("Finalization tasks failed.")
             click.echo(UpgradeCmdTexts.finalization_failed)

--- a/platform/services/installer/app/platform_utils/management/management.py
+++ b/platform/services/installer/app/platform_utils/management/management.py
@@ -4,6 +4,7 @@
 """Platform management functions"""
 
 import logging
+from time import sleep
 
 import kubernetes
 from kubernetes.client.exceptions import ApiException
@@ -251,6 +252,8 @@ def _patch_platform(config: UpgradeConfig, replicas: int) -> None:  # noqa: C901
             action = "add" if replicas == 0 else "remove"
             _replace_daemon_set_with_fetch_retry(apps_api=apps_api, daemon_set=daemon_set, action=action)
 
+        restart_jobs_after_revert()
+
         for daemon_set in daemon_sets:
             _ensure_desired_replicas(core_api=core_api, obj=daemon_set, replicas=replicas)
 
@@ -479,3 +482,65 @@ def remove_platform_workloads_tasks(config: UpgradeConfig):  # noqa: ANN201,C901
             except PodStillPresent as err:
                 logger.exception(err)
                 raise
+
+
+def restart_jobs_after_revert() -> None:
+    """Restarts specific jobs after revert operation."""
+    jobs_to_restart = [
+        "impt-etcd-auth",
+        "impt-kafka-provisioning",
+    ]
+
+    for job_name in jobs_to_restart:
+        try:
+            _restart_job(job_name=job_name, namespace=PLATFORM_NAMESPACE)
+        except Exception as e:
+            logger.error(f"Failed to restart job {job_name}: {e}")
+
+def _restart_job(job_name: str, namespace: str) -> None:
+    """Restart a Kubernetes Job by deleting its pods to force recreation."""
+    logger.info(f"Restarting job: {job_name} in namespace: {namespace}")
+    with kubernetes.client.ApiClient() as client:
+        batch_api = kubernetes.client.BatchV1Api(client)
+        logger.info(f"Restarting job: {job_name} in namespace: {namespace} - 2")
+        try:
+            # Get the existing Job manifest
+            job = batch_api.read_namespaced_job(name=job_name, namespace=namespace)
+            logger.info(f"Restarting job: {job_name} in namespace: {namespace} - 3")
+            # Delete the existing Job
+            batch_api.delete_namespaced_job(
+                name=job_name,
+                namespace=namespace,
+                body=kubernetes.client.V1DeleteOptions(propagation_policy="Foreground")
+            )
+            logger.info(f"Restarting job: {job_name} in namespace: {namespace} - 4")
+            # Wait for the Job to be fully deleted
+            for retry_count in range(10):
+                try:
+                    batch_api.read_namespaced_job(name=job_name, namespace=namespace)
+                except ApiException as e:
+                    if e.status == 404:
+                        break
+                sleep(1)
+            logger.info(f"Restarting job: {job_name} in namespace: {namespace} - 5")
+            # Remove fields that should not be set on creation
+            job.metadata.creation_timestamp = None
+            job.metadata.resource_version = None
+            job.metadata.uid = None
+            job.status = None
+            if job.metadata.labels.get("controller-uid"):
+                del job.metadata.labels["controller-uid"]
+            if job.metadata.labels.get("batch.kubernetes.io/controller-uid"):
+                del job.metadata.labels["batch.kubernetes.io/controller-uid"]
+            if job.spec.template.metadata.labels.get("controller-uid"):
+                del job.spec.template.metadata.labels["controller-uid"]
+            if job.spec.template.metadata.labels.get("batch.kubernetes.io/controller-uid"):
+                del job.spec.template.metadata.labels["batch.kubernetes.io/controller-uid"]
+            job.spec.selector = None
+            logger.info(f"New job content: {job}")
+            batch_api.create_namespaced_job(namespace=namespace, body=job)
+            logger.info(f"Restarting job: {job_name} in namespace: {namespace} - 6")
+        except ApiException as e:
+            logger.error(f"Exception when restarting job {job_name}: {e}")
+        except Exception as e:
+            logger.error(f"Unexpected error when restarting job {job_name}: {e}")

--- a/platform/services/installer/app/platform_utils/management/management.py
+++ b/platform/services/installer/app/platform_utils/management/management.py
@@ -509,7 +509,7 @@ def _restart_job(job_name: str, namespace: str) -> None:
                 body=kubernetes.client.V1DeleteOptions(propagation_policy="Foreground"),
             )
             # Wait for the Job to be fully deleted
-            for retry_count in range(10):
+            for _ in range(10):
                 try:
                     batch_api.read_namespaced_job(name=job_name, namespace=namespace)
                 except ApiException as e:

--- a/platform/services/installer/app/platform_utils/management/management.py
+++ b/platform/services/installer/app/platform_utils/management/management.py
@@ -167,7 +167,7 @@ def _replace_statefulset_with_fetch_retry(
         raise
 
 
-def _patch_platform(config: UpgradeConfig, replicas: int) -> None:  # noqa: C901, PLR0912, PLR0915
+def _patch_platform(config: UpgradeConfig, replicas: int, revert: bool = False) -> None:  # noqa: C901, PLR0912, PLR0915
     """Patch Platform by stopping or starting all Platform's pods."""
     KubernetesConfigHandler(kube_config=config.kube_config.value)
 
@@ -252,13 +252,14 @@ def _patch_platform(config: UpgradeConfig, replicas: int) -> None:  # noqa: C901
             action = "add" if replicas == 0 else "remove"
             _replace_daemon_set_with_fetch_retry(apps_api=apps_api, daemon_set=daemon_set, action=action)
 
-        restart_jobs_after_revert()
-
         for daemon_set in daemon_sets:
             _ensure_desired_replicas(core_api=core_api, obj=daemon_set, replicas=replicas)
 
         for deployment in deployments:
             _ensure_desired_replicas(core_api=core_api, obj=deployment, replicas=replicas)
+
+        if revert:
+            restart_jobs_after_revert()
 
         for stateful_set in stateful_sets:
             _ensure_desired_replicas(core_api=core_api, obj=stateful_set, replicas=replicas)
@@ -288,9 +289,9 @@ def stop_platform(config: UpgradeConfig) -> None:
     _patch_platform(config=config, replicas=0)
 
 
-def restore_platform(config: UpgradeConfig) -> None:
+def restore_platform(config: UpgradeConfig, revert: bool = False) -> None:
     """Restore Platform by starting all Platform's pods."""
-    _patch_platform(config=config, replicas=1)
+    _patch_platform(config=config, replicas=1, revert=revert)
 
 
 def get_ordered_deployments(apps_api: kubernetes.client.AppsV1Api) -> list[kubernetes.client.V1Deployment]:
@@ -486,34 +487,27 @@ def remove_platform_workloads_tasks(config: UpgradeConfig):  # noqa: ANN201,C901
 
 def restart_jobs_after_revert() -> None:
     """Restarts specific jobs after revert operation."""
-    jobs_to_restart = [
+    for job_name in (
         "impt-etcd-auth",
         "impt-kafka-provisioning",
-    ]
+    ):
+        _restart_job(job_name=job_name, namespace=PLATFORM_NAMESPACE)
 
-    for job_name in jobs_to_restart:
-        try:
-            _restart_job(job_name=job_name, namespace=PLATFORM_NAMESPACE)
-        except Exception as e:
-            logger.error(f"Failed to restart job {job_name}: {e}")
 
 def _restart_job(job_name: str, namespace: str) -> None:
-    """Restart a Kubernetes Job by deleting its pods to force recreation."""
+    """Restart a Kubernetes Job by deleting it and making its copy."""
     logger.info(f"Restarting job: {job_name} in namespace: {namespace}")
     with kubernetes.client.ApiClient() as client:
         batch_api = kubernetes.client.BatchV1Api(client)
-        logger.info(f"Restarting job: {job_name} in namespace: {namespace} - 2")
         try:
             # Get the existing Job manifest
             job = batch_api.read_namespaced_job(name=job_name, namespace=namespace)
-            logger.info(f"Restarting job: {job_name} in namespace: {namespace} - 3")
             # Delete the existing Job
             batch_api.delete_namespaced_job(
                 name=job_name,
                 namespace=namespace,
-                body=kubernetes.client.V1DeleteOptions(propagation_policy="Foreground")
+                body=kubernetes.client.V1DeleteOptions(propagation_policy="Foreground"),
             )
-            logger.info(f"Restarting job: {job_name} in namespace: {namespace} - 4")
             # Wait for the Job to be fully deleted
             for retry_count in range(10):
                 try:
@@ -522,7 +516,6 @@ def _restart_job(job_name: str, namespace: str) -> None:
                     if e.status == 404:
                         break
                 sleep(1)
-            logger.info(f"Restarting job: {job_name} in namespace: {namespace} - 5")
             # Remove fields that should not be set on creation
             job.metadata.creation_timestamp = None
             job.metadata.resource_version = None
@@ -537,9 +530,7 @@ def _restart_job(job_name: str, namespace: str) -> None:
             if job.spec.template.metadata.labels.get("batch.kubernetes.io/controller-uid"):
                 del job.spec.template.metadata.labels["batch.kubernetes.io/controller-uid"]
             job.spec.selector = None
-            logger.info(f"New job content: {job}")
             batch_api.create_namespaced_job(namespace=namespace, body=job)
-            logger.info(f"Restarting job: {job_name} in namespace: {namespace} - 6")
         except ApiException as e:
             logger.error(f"Exception when restarting job {job_name}: {e}")
         except Exception as e:


### PR DESCRIPTION
## 📝 Description

Restart of jobs responsible for configuration of etcd and kafka after revert of a failed upgrade. Thanks this configuration removed during upgrade will be restored.

- Fixes #1466 #1457

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

When upgrading the 2.13.0 version to 2.13.1 - break this operation to force an installer to execute the revert operation. Check if after finish of this operation - the application works correctly.

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
