### PR TITLE
allowing OPTIONS calls to the ../resumable endpoint

### DIFF
--- a/deploy/charts/istio/istio-gateway/chart/values.yaml
+++ b/deploy/charts/istio/istio-gateway/chart/values.yaml
@@ -257,6 +257,10 @@ _internal_defaults_do_not_set:
                 - "/intel-admin/deployment-config.json"
               notPorts:
                 - "8080"
+          - operation:
+              methods: [ "OPTIONS" ]
+              paths:
+                - "/api/v1/organizations/*/workspaces/*/projects/uploads/resumable"
         from:
           - source:
               requestPrincipals:

--- a/deploy/charts/istio/istio-gateway/chart/values.yaml
+++ b/deploy/charts/istio/istio-gateway/chart/values.yaml
@@ -260,8 +260,8 @@ _internal_defaults_do_not_set:
           - operation:
               methods: [ "OPTIONS" ]
               paths:
-                - "/api/v1/organizations/*/workspaces/*/projects/uploads/resumable"
-                - "/api/v1/organizations/*/workspaces/*/datasets/uploads/resumable"
+                - "/api/v1/organizations/*/projects/uploads/resumable"
+                - "/api/v1/organizations/*/datasets/uploads/resumable"
         from:
           - source:
               requestPrincipals:

--- a/deploy/charts/istio/istio-gateway/chart/values.yaml
+++ b/deploy/charts/istio/istio-gateway/chart/values.yaml
@@ -260,8 +260,8 @@ _internal_defaults_do_not_set:
           - operation:
               methods: [ "OPTIONS" ]
               paths:
-                - "/api/v1/organizations/*/projects/uploads/resumable"
-                - "/api/v1/organizations/*/datasets/uploads/resumable"
+                - "/api/v1/organizations/{*}/workspaces/{*}/projects/uploads/resumable"
+                - "/api/v1/organizations/{*}/workspaces/{*}/datasets/uploads/resumable"
         from:
           - source:
               requestPrincipals:

--- a/deploy/charts/istio/istio-gateway/chart/values.yaml
+++ b/deploy/charts/istio/istio-gateway/chart/values.yaml
@@ -261,6 +261,7 @@ _internal_defaults_do_not_set:
               methods: [ "OPTIONS" ]
               paths:
                 - "/api/v1/organizations/*/workspaces/*/projects/uploads/resumable"
+                - "/api/v1/organizations/*/workspaces/*/datasets/uploads/resumable"
         from:
           - source:
               requestPrincipals:


### PR DESCRIPTION
## 📝 Description

- Fixes #1509 


## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Check if it is possible to import a project using geti-sdk (you can use for this purpose the following Jupyter notebook - https://github.com/open-edge-platform/geti-sdk/blob/main/notebooks/003_export_and_import_projects.ipynb).
Additionally - check if there is no possibility to send an OPTIONS request type to the endpoint other than the /api/v1/organizations/{org_id}/workspaces/{workspace_id}/projects/uploads/resumable

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
