### PR TITLE
Preserve kafka configuration - for 2.14 version

### DIFF
--- a/deploy/charts/impt/chart/charts/kafka/templates/statefulset.yaml
+++ b/deploy/charts/impt/chart/charts/kafka/templates/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
           command:
             - /bin/bash
           image: "{{ .Values.image.registry }}/{{ if .Values.image.repository }}{{ .Values.image.repository }}/{{ end }}{{ .Values.image.name }}"
-          imagePullPolicy: { { .Values.image.pullPolicy } }
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: volume-permissions
           resources:
             limits:

--- a/deploy/charts/impt/chart/charts/kafka/templates/statefulset.yaml
+++ b/deploy/charts/impt/chart/charts/kafka/templates/statefulset.yaml
@@ -15,7 +15,32 @@ spec:
       labels:
         {{- include "kafka.labels" . | nindent 8 }}
     spec:
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kafka.fullname" . }}
+      initContainers:
+        - args:
+            - -ec
+            - |
+              mkdir -p /data-folder/kafka/data
+              find /data-folder/kafka -type d -exec chown -v 10001 {} +
+          command:
+            - /bin/bash
+          image: "{{ .Values.image.registry }}/{{ if .Values.image.repository }}{{ .Values.image.repository }}/{{ end }}{{ .Values.image.name }}"
+          imagePullPolicy: { { .Values.image.pullPolicy } }
+          name: volume-permissions
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+          volumeMounts:
+            - mountPath: /data-folder
+              name: kafka-data
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ if .Values.image.repository }}{{ .Values.image.repository }}/{{ end }}{{ .Values.image.name }}"
@@ -93,7 +118,7 @@ spec:
             - name: KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR
               value: "1"
             - name: KAFKA_LOG_DIRS
-              value: '/tmp/kraft-combined-logs'
+              value: '/var/lib/kafka/data'
             - name: KAFKA_SASL_ENABLED_MECHANISMS
               value: "PLAIN"
             - name: KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL
@@ -120,6 +145,9 @@ spec:
               mountPath: /etc/kafka/scripts/
             - name: tmp
               mountPath: /tmp
+            - mountPath: /var/lib/kafka/data
+              name: kafka-data
+              subPath: kafka/data
       volumes:
         - name: config
           configMap:
@@ -127,3 +155,6 @@ spec:
             defaultMode: 365
         - name: tmp
           emptyDir: {}
+        - name: kafka-data
+          persistentVolumeClaim:
+            claimName: data-storage-volume-claim

--- a/deploy/charts/impt/chart/charts/kafka/values.yaml
+++ b/deploy/charts/impt/chart/charts/kafka/values.yaml
@@ -31,6 +31,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+podSecurityContext:
+  enabled: true
+  fsGroup: 0
+  runAsUser: 0
+
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true


### PR DESCRIPTION
## 📝 Description

Currently, after restart of kafka statefulset or the whole cluster - kafka looses definitions of topics - which leads to problems with creating projects, starting training jobs etc.
To resolve this issue - within this PR I configured kafka to keep its logs in a permanent storage - provided by PVC.

## ✨ Type of Change

Select the type of change your PR introduces:

- [x] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [ ] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
