### PR TITLE
When a promise failed, the whole queue was ruined

### DIFF
--- a/web_ui/packages/smart-tools/src/segment-anything/post-processing.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/post-processing.ts
@@ -6,6 +6,11 @@ import { Circle, Point, Polygon, Rect, RotatedRect, Shape, ShapeType } from '../
 import { approximateShape } from '../utils/tool-utils';
 import { type SegmentAnythingResult } from './interfaces';
 
+// Discard contours whose bounding box covers more than this fraction of the
+// image — SAM occasionally returns a single mask that's basically the whole
+// frame and is never what the user wanted.
+const MAX_CONTOUR_AREA_RATIO = 0.9;
+
 interface PostProcessorConfig {
     type: ShapeType;
     shapeFilter?: (shape: Shape) => boolean;
@@ -32,91 +37,75 @@ export class PostProcessor {
         config: PostProcessorConfig
     ): SegmentAnythingResult {
         const scales = this.scaleToOriginalSize(sizes);
-        const width = sizes.width;
-        const height = sizes.height;
-        const mat = this.CV.matFromArray(height, width, this.CV.CV_8U, pixels);
-
+        const mat = this.CV.matFromArray(sizes.height, sizes.width, this.CV.CV_8U, pixels);
         const contours = new this.CV.MatVector();
-        const hierachy: OpenCVTypes.Mat = new this.CV.Mat();
-
-        this.CV.findContours(mat, contours, hierachy, this.CV.RETR_EXTERNAL, this.CV.CHAIN_APPROX_NONE);
-
-        let maxContourIdx = 0;
-        let maxArea = -1;
+        const hierarchy: OpenCVTypes.Mat = new this.CV.Mat();
 
         const shapes: Shape[] = [];
         const areas: number[] = [];
         const imageArea = sizes.originalWidth * sizes.originalHeight;
-        for (let idx = 0; idx < Number(contours.size()); idx++) {
-            const contour = contours.get(idx);
-            const optimizedContour = approximateShape(this.CV, contour);
-            const area = this.CV.contourArea(optimizedContour, false);
+        let maxContourIdx = 0;
+        let maxArea = -1;
 
-            const shape = this.contourToShape(optimizedContour, config, scales);
+        try {
+            this.CV.findContours(mat, contours, hierarchy, this.CV.RETR_EXTERNAL, this.CV.CHAIN_APPROX_NONE);
 
-            // Get rid of results that might take up the whole image
-            const boundingBox = this.contourToRectangle(optimizedContour, scales);
-            if ((boundingBox.width * boundingBox.height) / imageArea < 0.9) {
-                if (config.shapeFilter === undefined || config.shapeFilter(shape)) {
+            for (let idx = 0; idx < Number(contours.size()); idx++) {
+                const contour = contours.get(idx);
+                const optimized = approximateShape(this.CV, contour);
+                try {
+                    const bbox = this.contourToRectangle(optimized, scales);
+                    if ((bbox.width * bbox.height) / imageArea >= MAX_CONTOUR_AREA_RATIO) continue;
+
+                    const shape = this.contourToShape(optimized, config, scales);
+                    if (config.shapeFilter && !config.shapeFilter(shape)) continue;
+
+                    const area = this.CV.contourArea(optimized, false);
                     shapes.push(shape);
                     areas.push(area);
                     if (area > maxArea) {
                         maxArea = area;
                         maxContourIdx = shapes.length - 1;
                     }
+                } finally {
+                    optimized?.delete();
+                    contour?.delete();
                 }
             }
-
-            optimizedContour?.delete();
-            contour?.delete();
+        } finally {
+            contours.delete();
+            hierarchy.delete();
+            mat.delete();
         }
-
-        contours.delete();
-        hierachy.delete();
-        mat.delete();
-
-        // TODO: filter contours based on size (i.e. larger than x%, smaller than 90% of image)
-        // TODO: give some kind of score based on area and if the points are
-        // (not) included in the contour
 
         return { areas, maxContourIdx, shapes };
     }
 
-    private contourToShape = (
-        optimizedContour: OpenCVTypes.Mat,
-        config: PostProcessorConfig,
-        scales: ScaleToSize
-    ): Shape => {
+    private contourToShape(contour: OpenCVTypes.Mat, config: PostProcessorConfig, scales: ScaleToSize): Shape {
         switch (config.type) {
             case 'polygon':
-                return this.contourToPolygon(optimizedContour, scales);
+                return this.contourToPolygon(contour, scales);
             case 'rect':
-                return this.contourToRectangle(optimizedContour, scales);
+                return this.contourToRectangle(contour, scales);
             case 'rotated-rect':
-                return this.contourToRotatedRectangle(optimizedContour, scales);
+                return this.contourToRotatedRectangle(contour, scales);
             case 'circle':
-                return this.contourToCircle(optimizedContour, scales);
+                return this.contourToCircle(contour, scales);
             default:
                 throw new Error('Can not create keypoint using SAM');
         }
-    };
+    }
 
-    private contourToPolygon(optimizedContour: OpenCVTypes.Mat, { scaleX, scaleY }: ScaleToSize): Polygon {
+    private contourToPolygon(contour: OpenCVTypes.Mat, { scaleX, scaleY }: ScaleToSize): Polygon {
         const points: Point[] = [];
-
-        for (let row = 0; row < optimizedContour.rows; row++) {
-            const x = scaleX(optimizedContour.intAt(row, 0));
-            const y = scaleY(optimizedContour.intAt(row, 1));
-
-            points.push({ x, y });
+        for (let row = 0; row < contour.rows; row++) {
+            points.push({ x: scaleX(contour.intAt(row, 0)), y: scaleY(contour.intAt(row, 1)) });
         }
-
         return { shapeType: 'polygon', points };
     }
 
-    private contourToRectangle(optimizedContour: OpenCVTypes.Mat, { scaleX, scaleY }: ScaleToSize): Rect {
-        const { x, y, width, height } = this.CV.boundingRect(optimizedContour);
-
+    private contourToRectangle(contour: OpenCVTypes.Mat, { scaleX, scaleY }: ScaleToSize): Rect {
+        const { x, y, width, height } = this.CV.boundingRect(contour);
         return {
             shapeType: 'rect',
             x: scaleX(x),
@@ -126,13 +115,12 @@ export class PostProcessor {
         };
     }
 
-    private contourToRotatedRectangle(optimizedContour: OpenCVTypes.Mat, { scaleX, scaleY }: ScaleToSize): RotatedRect {
+    private contourToRotatedRectangle(contour: OpenCVTypes.Mat, { scaleX, scaleY }: ScaleToSize): RotatedRect {
         const {
             angle,
             center: { x, y },
             size: { width, height },
-        } = this.CV.minAreaRect(optimizedContour);
-
+        } = this.CV.minAreaRect(contour);
         return {
             shapeType: 'rotated-rect',
             x: scaleX(x),
@@ -143,12 +131,11 @@ export class PostProcessor {
         };
     }
 
-    private contourToCircle(optimizedContour: OpenCVTypes.Mat, { scaleX, scaleY }: ScaleToSize): Circle {
+    private contourToCircle(contour: OpenCVTypes.Mat, { scaleX, scaleY }: ScaleToSize): Circle {
         const {
             center: { x, y },
             size: { width, height },
-        } = this.CV.minAreaRect(optimizedContour);
-
+        } = this.CV.minAreaRect(contour);
         return {
             shapeType: 'circle',
             x: scaleX(x),
@@ -157,12 +144,10 @@ export class PostProcessor {
         };
     }
 
-    private scaleToOriginalSize(sizes: Sizes): ScaleToSize {
-        const { width, height, originalWidth, originalHeight } = sizes;
-
+    private scaleToOriginalSize({ width, height, originalWidth, originalHeight }: Sizes): ScaleToSize {
         return {
-            scaleX: (x: number) => Math.round((x * originalWidth) / width),
-            scaleY: (y: number) => Math.round((y * originalHeight) / height),
+            scaleX: (x) => Math.round((x * originalWidth) / width),
+            scaleY: (y) => Math.round((y * originalHeight) / height),
         };
     }
 }

--- a/web_ui/packages/smart-tools/src/segment-anything/post-processing.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/post-processing.ts
@@ -37,46 +37,48 @@ export class PostProcessor {
         config: PostProcessorConfig
     ): SegmentAnythingResult {
         const scales = this.scaleToOriginalSize(sizes);
-        const mat = this.CV.matFromArray(sizes.height, sizes.width, this.CV.CV_8U, pixels);
+        const width = sizes.width;
+        const height = sizes.height;
+        const mat = this.CV.matFromArray(height, width, this.CV.CV_8U, pixels);
+
         const contours = new this.CV.MatVector();
         const hierarchy: OpenCVTypes.Mat = new this.CV.Mat();
+
+        this.CV.findContours(mat, contours, hierarchy, this.CV.RETR_EXTERNAL, this.CV.CHAIN_APPROX_NONE);
+
+        let maxContourIdx = 0;
+        let maxArea = -1;
 
         const shapes: Shape[] = [];
         const areas: number[] = [];
         const imageArea = sizes.originalWidth * sizes.originalHeight;
-        let maxContourIdx = 0;
-        let maxArea = -1;
+        for (let idx = 0; idx < Number(contours.size()); idx++) {
+            const contour = contours.get(idx);
+            const optimizedContour = approximateShape(this.CV, contour);
+            const area = this.CV.contourArea(optimizedContour, false);
 
-        try {
-            this.CV.findContours(mat, contours, hierarchy, this.CV.RETR_EXTERNAL, this.CV.CHAIN_APPROX_NONE);
+            const shape = this.contourToShape(optimizedContour, config, scales);
 
-            for (let idx = 0; idx < Number(contours.size()); idx++) {
-                const contour = contours.get(idx);
-                const optimized = approximateShape(this.CV, contour);
-                try {
-                    const bbox = this.contourToRectangle(optimized, scales);
-                    if ((bbox.width * bbox.height) / imageArea >= MAX_CONTOUR_AREA_RATIO) continue;
-
-                    const shape = this.contourToShape(optimized, config, scales);
-                    if (config.shapeFilter && !config.shapeFilter(shape)) continue;
-
-                    const area = this.CV.contourArea(optimized, false);
+            // Get rid of results that might take up the whole image
+            const boundingBox = this.contourToRectangle(optimizedContour, scales);
+            if ((boundingBox.width * boundingBox.height) / imageArea < MAX_CONTOUR_AREA_RATIO) {
+                if (config.shapeFilter === undefined || config.shapeFilter(shape)) {
                     shapes.push(shape);
                     areas.push(area);
                     if (area > maxArea) {
                         maxArea = area;
                         maxContourIdx = shapes.length - 1;
                     }
-                } finally {
-                    optimized?.delete();
-                    contour?.delete();
                 }
             }
-        } finally {
-            contours.delete();
-            hierarchy.delete();
-            mat.delete();
+
+            optimizedContour?.delete();
+            contour?.delete();
         }
+
+        contours.delete();
+        hierarchy.delete();
+        mat.delete();
 
         return { areas, maxContourIdx, shapes };
     }

--- a/web_ui/packages/smart-tools/src/segment-anything/pre-processing.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/pre-processing.ts
@@ -7,12 +7,15 @@ import type { OpenCVTypes } from '../opencv/interfaces';
 
 interface PreprocessorResult {
     tensor: Tensor;
+    width: number;
+    height: number;
     newWidth: number;
     newHeight: number;
 }
 
 export interface OpenCVPreprocessorConfig {
     normalize: {
+        enabled: boolean;
         mean?: number[];
         std?: number[];
     };
@@ -24,35 +27,44 @@ export interface OpenCVPreprocessorConfig {
 }
 
 export class OpenCVPreprocessor {
+    config: OpenCVPreprocessorConfig;
+
     constructor(
         private CV: OpenCVTypes.cv,
-        private config: OpenCVPreprocessorConfig
-    ) {}
+        config: OpenCVPreprocessorConfig
+    ) {
+        this.config = config;
+    }
 
     public process(initialImageData: ImageData): PreprocessorResult {
-        const mat = this.loadImage(initialImageData);
-        let blob: OpenCVTypes.Mat | null = null;
+        const imageCv = this.loadImage(initialImageData);
+
+        const preProcessedImage: OpenCVTypes.Mat = imageCv.clone();
+        let input: OpenCVTypes.Mat | null = null;
         try {
-            const { newWidth, newHeight } = this.resizeAndPad(mat);
+            const { width, height, newWidth, newHeight } = this.resizeImage(preProcessedImage);
 
-            mat.convertTo(mat, this.CV.CV_32F, 1 / 255);
-            this.normalize(mat);
+            // Apply color space transformations
+            preProcessedImage.convertTo(preProcessedImage, this.CV.CV_32F, 1 / 255);
+            this.processImage(preProcessedImage);
 
-            blob = this.CV.blobFromImage(mat);
-            if (!blob) {
+            input = this.CV.blobFromImage(preProcessedImage);
+            if (!input) {
                 throw new Error('Something went wrong with preprocessing the image.');
             }
 
-            // `blob.data32F` is a view into WASM memory owned by `blob`, which is freed in the
-            // `finally` block below. `session.run()` uploads the tensor data asynchronously
-            // (especially on the WebGPU EP), so we must copy into JS-owned memory.
-            const data = new Float32Array(blob.data32F);
+            // `input.data32F` is a view into WASM memory owned by OpenCV's `input` Mat, which is
+            // freed in the `finally` block below. `session.run()` uploads the tensor data
+            // asynchronously (especially on the WebGPU EP), so we must copy the data into a
+            // JS-owned Float32Array to avoid reading freed memory and hanging/garbage output.
+            const data = new Float32Array(input.data32F);
             const tensor = new Tensor('float32', data, [1, 3, this.config.size, this.config.size]);
 
-            return { tensor, newWidth, newHeight };
+            return { tensor, width, height, newWidth, newHeight };
         } finally {
-            mat.delete();
-            blob?.delete();
+            imageCv.delete();
+            preProcessedImage?.delete();
+            input?.delete();
         }
     }
 
@@ -60,57 +72,103 @@ export class OpenCVPreprocessor {
         const src = this.CV.matFromImageData(imageData);
         // Strip the alpha channel — the ORT tensor only wants 3 channels.
         this.CV.cvtColor(src, src, this.CV.COLOR_RGBA2RGB, 0);
+
         return src;
     }
 
-    private resizeAndPad(mat: OpenCVTypes.Mat): { newWidth: number; newHeight: number } {
-        const { resize, squareImage, pad, padSize, size } = this.config;
+    private resizeImage(preProcessedImage: OpenCVTypes.Mat) {
+        const width = this.config.pad ? this.config.padSize : preProcessedImage.cols;
+        const height = this.config.pad ? this.config.padSize : preProcessedImage.rows;
 
-        if (resize) {
-            const [w, h] = squareImage
-                ? [size, size]
-                : mat.cols > mat.rows
-                  ? [size, Math.ceil(mat.rows * (size / mat.cols))]
-                  : [Math.ceil(mat.cols * (size / mat.rows)), size];
-            this.CV.resize(mat, mat, new this.CV.Size(w, h), 0, 0, this.CV.INTER_LANCZOS4);
+        if (this.config.resize) {
+            const CV_INTERPOLATION = this.CV.INTER_LANCZOS4;
+            if (!this.config.squareImage) {
+                if (preProcessedImage.cols > preProcessedImage.rows) {
+                    const scale = this.config.size / preProcessedImage.cols;
+                    const h = Math.ceil(preProcessedImage.rows * scale);
+                    const w = this.config.size;
+                    this.CV.resize(
+                        preProcessedImage,
+                        preProcessedImage,
+                        new this.CV.Size(w, h),
+                        0,
+                        0,
+                        CV_INTERPOLATION
+                    );
+                } else {
+                    const scale = this.config.size / preProcessedImage.rows;
+                    const h = this.config.size;
+                    const w = Math.ceil(preProcessedImage.cols * scale);
+                    this.CV.resize(
+                        preProcessedImage,
+                        preProcessedImage,
+                        new this.CV.Size(w, h),
+                        0,
+                        0,
+                        CV_INTERPOLATION
+                    );
+                }
+            } else {
+                this.CV.resize(
+                    preProcessedImage,
+                    preProcessedImage,
+                    new this.CV.Size(this.config.size, this.config.size),
+                    0,
+                    0,
+                    CV_INTERPOLATION
+                );
+            }
         }
 
-        const newWidth = mat.cols;
-        const newHeight = mat.rows;
+        const newWidth = preProcessedImage.cols;
+        const newHeight = preProcessedImage.rows;
 
-        if (pad) {
+        if (this.config.pad) {
             this.CV.copyMakeBorder(
-                mat,
-                mat,
+                preProcessedImage,
+                preProcessedImage,
                 0,
-                padSize - newHeight,
+                height - preProcessedImage.rows,
                 0,
-                padSize - newWidth,
+                width - preProcessedImage.cols,
                 this.CV.BORDER_CONSTANT,
                 new this.CV.Scalar(0, 0, 0, 0)
             );
         }
 
-        return { newWidth, newHeight };
+        return { width, height, newWidth, newHeight };
     }
 
-    private normalize(dst: OpenCVTypes.Mat): void {
-        const { mean, std } = this.config.normalize;
-        if (mean) this.applyScalar(dst, mean, 'subtract');
-        if (std) this.applyScalar(dst, std, 'divide');
-    }
-
-    private applyScalar(dst: OpenCVTypes.Mat, [c0, c1, c2]: number[], op: 'subtract' | 'divide'): void {
-        const constant = dst.clone();
+    private processImage(dst: OpenCVTypes.Mat): void {
+        let norm: OpenCVTypes.Mat | null = null;
+        let stdDev: OpenCVTypes.Mat | null = null;
         try {
-            constant.setTo(new this.CV.Scalar(c0, c1, c2));
-            if (op === 'subtract') {
-                this.CV.subtract(dst, constant, dst);
-            } else {
-                this.CV.divide(dst, constant, dst, 1);
+            if (this.config.normalize.mean) {
+                const normValue = new this.CV.Scalar(
+                    this.config.normalize.mean[0],
+                    this.config.normalize.mean[1],
+                    this.config.normalize.mean[2]
+                );
+                norm = dst.clone();
+                norm.setTo(normValue);
+
+                this.CV.subtract(dst, norm, dst);
+            }
+
+            if (this.config.normalize.std) {
+                const stdDevValues = new this.CV.Scalar(
+                    this.config.normalize.std[0],
+                    this.config.normalize.std[1],
+                    this.config.normalize.std[2]
+                );
+                stdDev = dst.clone();
+                stdDev.setTo(stdDevValues);
+
+                this.CV.divide(dst, stdDev, dst, 1);
             }
         } finally {
-            constant.delete();
+            stdDev?.delete();
+            norm?.delete();
         }
     }
 }

--- a/web_ui/packages/smart-tools/src/segment-anything/pre-processing.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/pre-processing.ts
@@ -7,15 +7,12 @@ import type { OpenCVTypes } from '../opencv/interfaces';
 
 interface PreprocessorResult {
     tensor: Tensor;
-    width: number;
-    height: number;
     newWidth: number;
     newHeight: number;
 }
 
 export interface OpenCVPreprocessorConfig {
     normalize: {
-        enabled: boolean;
         mean?: number[];
         std?: number[];
     };
@@ -27,157 +24,93 @@ export interface OpenCVPreprocessorConfig {
 }
 
 export class OpenCVPreprocessor {
-    config: OpenCVPreprocessorConfig;
-
     constructor(
         private CV: OpenCVTypes.cv,
-        config: OpenCVPreprocessorConfig
-    ) {
-        this.config = config;
-    }
+        private config: OpenCVPreprocessorConfig
+    ) {}
 
     public process(initialImageData: ImageData): PreprocessorResult {
-        const imageCv = this.loadImage(initialImageData);
-
-        const preProcessedImage: OpenCVTypes.Mat = imageCv.clone();
-        let input: OpenCVTypes.Mat | null = null;
+        const mat = this.loadImage(initialImageData);
+        let blob: OpenCVTypes.Mat | null = null;
         try {
-            const { width, height, newWidth, newHeight } = this.resizeImage(preProcessedImage);
+            const { newWidth, newHeight } = this.resizeAndPad(mat);
 
-            // Apply color space transformations
-            preProcessedImage.convertTo(preProcessedImage, this.CV.CV_32F, 1 / 255);
-            this.processImage(preProcessedImage);
+            mat.convertTo(mat, this.CV.CV_32F, 1 / 255);
+            this.normalize(mat);
 
-            input = this.CV.blobFromImage(preProcessedImage);
-            if (!input) {
+            blob = this.CV.blobFromImage(mat);
+            if (!blob) {
                 throw new Error('Something went wrong with preprocessing the image.');
             }
 
-            // `input.data32F` is a view into WASM memory owned by OpenCV's `input` Mat, which is
-            // freed in the `finally` block below. `session.run()` uploads the tensor data
-            // asynchronously (especially on the WebGPU EP), so we must copy the data into a
-            // JS-owned Float32Array to avoid reading freed memory and hanging/garbage output.
-            const data = new Float32Array(input.data32F);
+            // `blob.data32F` is a view into WASM memory owned by `blob`, which is freed in the
+            // `finally` block below. `session.run()` uploads the tensor data asynchronously
+            // (especially on the WebGPU EP), so we must copy into JS-owned memory.
+            const data = new Float32Array(blob.data32F);
             const tensor = new Tensor('float32', data, [1, 3, this.config.size, this.config.size]);
 
-            return { tensor, width, height, newWidth, newHeight };
+            return { tensor, newWidth, newHeight };
         } finally {
-            imageCv.delete();
-            preProcessedImage?.delete();
-            input?.delete();
+            mat.delete();
+            blob?.delete();
         }
     }
 
     private loadImage(imageData: ImageData): OpenCVTypes.Mat {
-        // TODO: check if it is faster / more appropriate if we traser this value
-        // https://github.com/GoogleChromeLabs/comlink#comlinktransfervalue-transferables-and-comlinkproxyvalue
         const src = this.CV.matFromImageData(imageData);
-        // This is important as otherwise the matrix has too many channels
-        // and we don't want to convert the alpha channel to the ort tesnsor
+        // Strip the alpha channel — the ORT tensor only wants 3 channels.
         this.CV.cvtColor(src, src, this.CV.COLOR_RGBA2RGB, 0);
-
         return src;
     }
 
-    private resizeImage(preProcessedImage: OpenCVTypes.Mat) {
-        const width = this.config.pad ? this.config.padSize : preProcessedImage.cols;
-        const height = this.config.pad ? this.config.padSize : preProcessedImage.rows;
+    private resizeAndPad(mat: OpenCVTypes.Mat): { newWidth: number; newHeight: number } {
+        const { resize, squareImage, pad, padSize, size } = this.config;
 
-        if (this.config.resize) {
-            const CV_INTERPOLATION = this.CV.INTER_LANCZOS4;
-            if (!this.config.squareImage) {
-                if (preProcessedImage.cols > preProcessedImage.rows) {
-                    const scale = this.config.size / preProcessedImage.cols;
-                    const h = Math.ceil(preProcessedImage.rows * scale);
-                    const w = this.config.size;
-                    this.CV.resize(
-                        preProcessedImage,
-                        preProcessedImage,
-                        new this.CV.Size(w, h),
-                        0,
-                        0,
-                        CV_INTERPOLATION
-                    );
-                } else {
-                    const scale = this.config.size / preProcessedImage.rows;
-                    const h = this.config.size;
-                    const w = Math.ceil(preProcessedImage.cols * scale);
-                    this.CV.resize(
-                        preProcessedImage,
-                        preProcessedImage,
-                        new this.CV.Size(w, h),
-                        0,
-                        0,
-                        CV_INTERPOLATION
-                    );
-                }
-            } else {
-                this.CV.resize(
-                    preProcessedImage,
-                    preProcessedImage,
-                    new this.CV.Size(this.config.size, this.config.size),
-                    0,
-                    0,
-                    CV_INTERPOLATION
-                );
-            }
+        if (resize) {
+            const [w, h] = squareImage
+                ? [size, size]
+                : mat.cols > mat.rows
+                  ? [size, Math.ceil(mat.rows * (size / mat.cols))]
+                  : [Math.ceil(mat.cols * (size / mat.rows)), size];
+            this.CV.resize(mat, mat, new this.CV.Size(w, h), 0, 0, this.CV.INTER_LANCZOS4);
         }
 
-        const newWidth = preProcessedImage.cols;
-        const newHeight = preProcessedImage.rows;
+        const newWidth = mat.cols;
+        const newHeight = mat.rows;
 
-        if (this.config.pad) {
+        if (pad) {
             this.CV.copyMakeBorder(
-                preProcessedImage,
-                preProcessedImage,
+                mat,
+                mat,
                 0,
-                height - preProcessedImage.rows,
+                padSize - newHeight,
                 0,
-                width - preProcessedImage.cols,
+                padSize - newWidth,
                 this.CV.BORDER_CONSTANT,
                 new this.CV.Scalar(0, 0, 0, 0)
             );
         }
 
-        return {
-            width,
-            height,
-            newWidth,
-            newHeight,
-        };
+        return { newWidth, newHeight };
     }
 
-    private processImage(dst: OpenCVTypes.Mat): void {
-        // RITM requires the image to normalized. RITM code uses theses hardcoded values for some reason.
-        let norm: OpenCVTypes.Mat | null = null;
-        let stdDev: OpenCVTypes.Mat | null = null;
+    private normalize(dst: OpenCVTypes.Mat): void {
+        const { mean, std } = this.config.normalize;
+        if (mean) this.applyScalar(dst, mean, 'subtract');
+        if (std) this.applyScalar(dst, std, 'divide');
+    }
+
+    private applyScalar(dst: OpenCVTypes.Mat, [c0, c1, c2]: number[], op: 'subtract' | 'divide'): void {
+        const constant = dst.clone();
         try {
-            if (this.config.normalize.mean) {
-                const normValue = new this.CV.Scalar(
-                    this.config.normalize.mean[0],
-                    this.config.normalize.mean[1],
-                    this.config.normalize.mean[2]
-                );
-                norm = dst.clone();
-                norm.setTo(normValue);
-
-                this.CV.subtract(dst, norm, dst);
-            }
-
-            if (this.config.normalize.std) {
-                const stdDevValues = new this.CV.Scalar(
-                    this.config.normalize.std[0],
-                    this.config.normalize.std[1],
-                    this.config.normalize.std[2]
-                );
-                stdDev = dst.clone();
-                stdDev.setTo(stdDevValues);
-
-                this.CV.divide(dst, stdDev, dst, 1);
+            constant.setTo(new this.CV.Scalar(c0, c1, c2));
+            if (op === 'subtract') {
+                this.CV.subtract(dst, constant, dst);
+            } else {
+                this.CV.divide(dst, constant, dst, 1);
             }
         } finally {
-            stdDev?.delete();
-            norm?.delete();
+            constant.delete();
         }
     }
 }

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything-decoder.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything-decoder.ts
@@ -11,8 +11,6 @@ import { PostProcessor } from './post-processing';
 import { EncodingOutput } from './segment-anything-encoder';
 import { type Session } from './session';
 
-type cv = OpenCVTypes;
-
 type InteractiveAnnotationPoint = Point & { positive: boolean };
 
 export interface SegmentAnythingPrompt {
@@ -21,106 +19,84 @@ export interface SegmentAnythingPrompt {
     outputConfig: { type: ShapeType };
 }
 
+const argmax = (data: ArrayLike<number>, length: number): number => {
+    let best = 0;
+    for (let i = 1; i < length; i++) {
+        if (data[i] > data[best]) best = i;
+    }
+    return best;
+};
+
 export class SegmentAnythingDecoder {
     constructor(
-        private cv: cv,
+        private cv: OpenCVTypes,
         private session: Session
     ) {}
 
     public async process(encodingOutput: EncodingOutput, input: SegmentAnythingPrompt): Promise<SegmentAnythingResult> {
-        const { masks, iouPredictions } = await this.processDecoder(
-            { boxes: input.boxes ?? [], points: input.points ?? [] },
-            encodingOutput
+        const points = input.points ?? [];
+        const boxes = input.boxes ?? [];
+        const { masks, iouPredictions } = await this.runDecoder(points, boxes, encodingOutput);
+
+        const [, , height, width] = masks.dims;
+        const maskIdx = argmax(iouPredictions.data as ArrayLike<number>, iouPredictions.dims[1]);
+        const maskOffset = maskIdx * height * width;
+
+        const pixels = new Uint8ClampedArray(height * width);
+        for (let i = 0; i < pixels.length; i++) {
+            pixels[i] = Number(masks.data[maskOffset + i]) > 0 ? 255 : 0;
+        }
+
+        const positivePoints = points.filter(({ positive }) => positive);
+
+        return new PostProcessor(this.cv).maskToAnnotationShape(
+            pixels,
+            {
+                width,
+                height,
+                originalWidth: encodingOutput.originalWidth + 1,
+                originalHeight: encodingOutput.originalHeight + 1,
+            },
+            {
+                ...input.outputConfig,
+                shapeFilter: (shape) => positivePoints.some((point) => isPointInShape(shape, point)),
+            }
         );
-
-        const maskIdx = this.getIndexOfMaskWithHighestConfidence(iouPredictions);
-
-        const size = masks.dims[2] * masks.dims[3];
-        const maskOffset = maskIdx * size;
-        const pixels = new Uint8ClampedArray(new ArrayBuffer(size));
-
-        for (let y = 0; y < masks.dims[2]; y++) {
-            for (let x = 0; x < masks.dims[3]; x++) {
-                const value = Number(masks.data[maskOffset + y * masks.dims[3] + x]);
-
-                const idx = y * masks.dims[3] + x;
-                pixels[idx] = value > 0 ? 255 : 0;
-            }
-        }
-
-        const postProcessor = new PostProcessor(this.cv);
-
-        const positivePoints = input.points?.filter(({ positive }) => positive) ?? [];
-
-        const sizes = {
-            height: masks.dims[2],
-            width: masks.dims[3],
-            originalWidth: encodingOutput.originalWidth + 1,
-            originalHeight: encodingOutput.originalHeight + 1,
-        };
-
-        const results = postProcessor.maskToAnnotationShape(pixels, sizes, {
-            ...(input.outputConfig ?? { type: 'polygon' }),
-            shapeFilter: (shape) => positivePoints.some((point) => isPointInShape(shape, point)),
-        });
-        return results;
     }
 
-    private getIndexOfMaskWithHighestConfidence(iou_predictions: Tensor) {
-        let predictionIdx = 0;
-
-        for (let p = 0; p < iou_predictions.dims[1]; p++) {
-            if (iou_predictions.data[p] > iou_predictions.data[predictionIdx]) {
-                predictionIdx = p;
-            }
-        }
-
-        return predictionIdx;
-    }
-
-    private async processDecoder(
-        prompt: {
-            points: InteractiveAnnotationPoint[];
-            boxes: Point[][];
-        },
+    private async runDecoder(
+        points: InteractiveAnnotationPoint[],
+        boxes: Point[][],
         { encoderResult, originalWidth, originalHeight, newWidth, newHeight }: EncodingOutput
-    ): Promise<{
-        masks: Tensor;
-        iouPredictions: Tensor;
-    }> {
-        const pointCoords: number[] = [];
-        const pointLabels: number[] = [];
-
+    ): Promise<{ masks: Tensor; iouPredictions: Tensor }> {
         const xRatio = newWidth / originalWidth;
         const yRatio = newHeight / originalHeight;
 
-        for (const point of prompt.points) {
-            pointCoords.push(point.x * xRatio);
-            pointCoords.push(point.y * yRatio);
-            pointLabels.push(point.positive ? 1 : 0);
+        const pointCoords: number[] = [];
+        const pointLabels: number[] = [];
+
+        for (const p of points) {
+            pointCoords.push(p.x * xRatio, p.y * yRatio);
+            pointLabels.push(p.positive ? 1 : 0);
         }
 
-        if (prompt.boxes.length === 0) {
-            pointCoords.push(0);
-            pointCoords.push(0);
+        if (boxes.length === 0) {
+            // SAM requires at least one extra padding point when no box is given.
+            pointCoords.push(0, 0);
             pointLabels.push(-1);
         }
 
-        for (const box of prompt.boxes) {
-            pointCoords.push(box[0].x * xRatio);
-            pointCoords.push(box[0].y * yRatio);
-            pointLabels.push(2);
-            pointCoords.push(box[1].x * xRatio);
-            pointCoords.push(box[1].y * yRatio);
-            pointLabels.push(3);
+        for (const [tl, br] of boxes) {
+            pointCoords.push(tl.x * xRatio, tl.y * yRatio, br.x * xRatio, br.y * yRatio);
+            pointLabels.push(2, 3);
         }
 
         const ratio = 1024 / Math.max(originalHeight, originalWidth);
+        // TODO: reuse the low_res_masks output, also use existing polygons?
         const feeds: Record<string, Tensor> = {
             image_embeddings: new Tensor(encoderResult.type, encoderResult.data, encoderResult.dims),
-            // TODO: reuse the low_res_masks output, also use existing polygons?
             mask_input: new Tensor(new Float32Array(256 * 256).fill(1), [1, 1, 256, 256]),
-            has_mask_input: new Tensor(new Float32Array(1).fill(0), [1]),
+            has_mask_input: new Tensor(new Float32Array(1), [1]),
             orig_im_size: new Tensor(
                 new Float32Array([Math.round(originalHeight * ratio), Math.round(originalWidth * ratio)]),
                 [2]
@@ -129,11 +105,7 @@ export class SegmentAnythingDecoder {
             point_labels: new Tensor(new Float32Array(pointLabels), [1, pointLabels.length]),
         };
 
-        const outputData = await this.session.run(feeds);
-
-        return {
-            masks: outputData['masks'],
-            iouPredictions: outputData['iou_predictions'],
-        };
+        const out = await this.session.run(feeds);
+        return { masks: out['masks'], iouPredictions: out['iou_predictions'] };
     }
 }

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything-decoder.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything-decoder.ts
@@ -16,10 +16,9 @@ type cv = OpenCVTypes;
 type InteractiveAnnotationPoint = Point & { positive: boolean };
 
 export interface SegmentAnythingPrompt {
-    image: string | ArrayBuffer | undefined;
     points: InteractiveAnnotationPoint[] | undefined;
     boxes: Point[][] | undefined;
-    ouputConfig: { type: ShapeType };
+    outputConfig: { type: ShapeType };
 }
 
 export class SegmentAnythingDecoder {
@@ -61,7 +60,7 @@ export class SegmentAnythingDecoder {
         };
 
         const results = postProcessor.maskToAnnotationShape(pixels, sizes, {
-            ...(input.ouputConfig ?? { type: 'polygon' }),
+            ...(input.outputConfig ?? { type: 'polygon' }),
             shapeFilter: (shape) => positivePoints.some((point) => isPointInShape(shape, point)),
         });
         return results;
@@ -88,7 +87,6 @@ export class SegmentAnythingDecoder {
     ): Promise<{
         masks: Tensor;
         iouPredictions: Tensor;
-        lowResMasks: Tensor;
     }> {
         const pointCoords: number[] = [];
         const pointLabels: number[] = [];
@@ -136,7 +134,6 @@ export class SegmentAnythingDecoder {
         return {
             masks: outputData['masks'],
             iouPredictions: outputData['iou_predictions'],
-            lowResMasks: outputData['low_res_masks'],
         };
     }
 }

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything-encoder.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything-encoder.ts
@@ -42,9 +42,9 @@ export class SegmentAnythingEncoder {
     }
 
     public async processEncoder(initialImageData: ImageData) {
-        const result = this.preprocessor.process(initialImageData);
+        const { tensor, newWidth, newHeight } = this.preprocessor.process(initialImageData);
         console.time('[SAM] Encoding');
-        const outputData = await this.session.run({ x: result.tensor });
+        const outputData = await this.session.run({ x: tensor });
         console.timeEnd('[SAM] Encoding');
 
         const outputNames = await this.session.outputNames();
@@ -60,15 +60,10 @@ export class SegmentAnythingEncoder {
             type: gpuTensor.type as Tensor.Type,
         };
 
-        const originalWidth = initialImageData.width;
-        const originalHeight = initialImageData.height;
-        const newWidth = result.newWidth;
-        const newHeight = result.newHeight;
-
         return {
             encoderResult,
-            originalWidth,
-            originalHeight,
+            originalWidth: initialImageData.width,
+            originalHeight: initialImageData.height,
             newWidth,
             newHeight,
         };

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything-encoder.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything-encoder.ts
@@ -2,15 +2,12 @@
 // LIMITED EDGE SOFTWARE DISTRIBUTION LICENSE
 
 import type { OpenCVTypes } from '@geti/smart-tools/opencv';
-import type * as Comlink from 'comlink';
 import { Tensor } from 'onnxruntime-web';
 
 import { OpenCVPreprocessor, OpenCVPreprocessorConfig } from './pre-processing';
 import { type Session } from './session';
 
 type cv = typeof OpenCVTypes;
-
-type ModelSession = Session | Comlink.Remote<Session>;
 
 // A plain-object representation of ort.Tensor that survives structured-clone
 // (Comlink transfers between workers). ort.Tensor instances lose their class
@@ -36,32 +33,23 @@ export class SegmentAnythingEncoder {
     constructor(
         cv: cv,
         config: OpenCVPreprocessorConfig,
-        private session: ModelSession
+        private session: Session
     ) {
         this.preprocessor = new OpenCVPreprocessor(cv, config);
     }
 
-    public async processEncoder(initialImageData: ImageData) {
+    public async processEncoder(initialImageData: ImageData): Promise<EncodingOutput> {
         const { tensor, newWidth, newHeight } = this.preprocessor.process(initialImageData);
-        console.time('[SAM] Encoding');
         const outputData = await this.session.run({ x: tensor });
-        console.timeEnd('[SAM] Encoding');
-
         const outputNames = await this.session.outputNames();
         const gpuTensor = outputData[outputNames[0]];
 
-        // ort.Tensor instances lose their class identity (and `location` getter)
-        // when structured-cloned by Comlink across workers, causing onnxruntime
-        // >=1.20 to throw "invalid data location: undefined". Store raw typed
-        // array data so the decoder can reconstruct a valid tensor.
-        const encoderResult: SerializableTensor = {
-            data: (await gpuTensor.getData()) as Float32Array,
-            dims: [...gpuTensor.dims],
-            type: gpuTensor.type as Tensor.Type,
-        };
-
         return {
-            encoderResult,
+            encoderResult: {
+                data: (await gpuTensor.getData()) as Float32Array,
+                dims: [...gpuTensor.dims],
+                type: gpuTensor.type as Tensor.Type,
+            },
             originalWidth: initialImageData.width,
             originalHeight: initialImageData.height,
             newWidth,

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything-encoder.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything-encoder.ts
@@ -40,7 +40,9 @@ export class SegmentAnythingEncoder {
 
     public async processEncoder(initialImageData: ImageData): Promise<EncodingOutput> {
         const { tensor, newWidth, newHeight } = this.preprocessor.process(initialImageData);
+        console.time('[SAM] Encoding');
         const outputData = await this.session.run({ x: tensor });
+        console.timeEnd('[SAM] Encoding');
         const outputNames = await this.session.outputNames();
         const gpuTensor = outputData[outputNames[0]];
 

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything-wrapper.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything-wrapper.ts
@@ -12,6 +12,7 @@ import { EncodingOutput } from './segment-anything-encoder';
 
 const PRE_PROCESSOR_CONFIG: OpenCVPreprocessorConfig = {
     normalize: {
+        enabled: true,
         mean: [0.485, 0.456, 0.406],
         std: [0.229, 0.224, 0.225],
     },

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything-wrapper.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything-wrapper.ts
@@ -5,45 +5,44 @@ import type { OpenCVTypes } from '../opencv/interfaces';
 import { OpenCVLoader } from '../utils/opencv-loader';
 import { SegmentAnythingResult } from './interfaces';
 import { SegmentAnythingModels } from './models/models';
+import { OpenCVPreprocessorConfig } from './pre-processing';
 import { SegmentAnythingModel } from './segment-anything';
 import { SegmentAnythingPrompt } from './segment-anything-decoder';
 import { EncodingOutput } from './segment-anything-encoder';
 
+const PRE_PROCESSOR_CONFIG: OpenCVPreprocessorConfig = {
+    normalize: {
+        mean: [0.485, 0.456, 0.406],
+        std: [0.229, 0.224, 0.225],
+    },
+    resize: true,
+    size: 1024,
+    squareImage: false,
+    pad: true,
+    padSize: 1024,
+};
+
+const MODEL_PATHS = new Map([
+    ['encoder', SegmentAnythingModels.encoder],
+    ['decoder', SegmentAnythingModels.decoder],
+]);
+
 class SegmentAnythingModelWrapper {
     private model: SegmentAnythingModel;
 
-    constructor(private CV: OpenCVTypes.cv) {
-        const config = {
-            preProcessorConfig: {
-                normalize: {
-                    enabled: true,
-                    mean: [0.485, 0.456, 0.406],
-                    std: [0.229, 0.224, 0.225],
-                },
-                resize: true,
-                size: 1024,
-                squareImage: false,
-                pad: true,
-                padSize: 1024,
-            },
-            modelPaths: new Map([
-                ['encoder', SegmentAnythingModels.encoder],
-                ['decoder', SegmentAnythingModels.decoder],
-            ]),
-        };
-
-        this.model = new SegmentAnythingModel(this.CV, config.modelPaths, config.preProcessorConfig);
+    constructor(CV: OpenCVTypes.cv) {
+        this.model = new SegmentAnythingModel(CV, MODEL_PATHS, PRE_PROCESSOR_CONFIG);
     }
 
-    public async init(algorithm: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER'): Promise<void> {
-        await this.model.init(algorithm);
+    public init(algorithm: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER'): Promise<void> {
+        return this.model.init(algorithm);
     }
 
-    public async processEncoder(initialImageData: ImageData): Promise<EncodingOutput> {
+    public processEncoder(initialImageData: ImageData): Promise<EncodingOutput> {
         return this.model.processEncoder(initialImageData);
     }
 
-    public async processDecoder(
+    public processDecoder(
         encodingOutput: EncodingOutput,
         input: SegmentAnythingPrompt
     ): Promise<SegmentAnythingResult> {
@@ -52,9 +51,7 @@ class SegmentAnythingModelWrapper {
 }
 
 const buildSegmentAnythingInstance = async (): Promise<SegmentAnythingModelWrapper> => {
-    const opencv = await OpenCVLoader();
-
-    return new SegmentAnythingModelWrapper(opencv);
+    return new SegmentAnythingModelWrapper(await OpenCVLoader());
 };
 
 export { buildSegmentAnythingInstance, SegmentAnythingModelWrapper };

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything.ts
@@ -7,14 +7,46 @@ import { SegmentAnythingResult } from './interfaces';
 import { OpenCVPreprocessorConfig } from './pre-processing';
 import { SegmentAnythingDecoder, SegmentAnythingPrompt } from './segment-anything-decoder';
 import { EncodingOutput, SegmentAnythingEncoder } from './segment-anything-encoder';
-import { Session } from './session';
+import { Session, SessionPoisonedError } from './session';
 
 type cv = typeof OpenCVTypes;
 
+// Errors whose message points at the WebGPU / JSEP backend. When we see one
+// the right recovery is to drop `webgpu` from the EP list and retry on CPU.
+const WEBGPU_ERROR_PATTERN = /webgpu|jsep|wasm|initwasm|no available backend/i;
+
+const isWebGpuFailure = (err: unknown): boolean => {
+    if (err instanceof SessionPoisonedError) return true;
+    const message = err instanceof Error ? err.message : String(err ?? '');
+    return WEBGPU_ERROR_PATTERN.test(message);
+};
+
+/**
+ * Create a Session, falling back to CPU-only EPs if the first attempt fails
+ * with a WebGPU / JSEP initialisation error. Some environments (Tauri WebView,
+ * non-cross-origin-isolated tabs, broken GPU drivers) can't load the threaded
+ * JSEP wasm; the CPU EP still works there.
+ */
 const createSession = async (modelPath: string): Promise<Session> => {
     const session = new Session();
-    await session.init(modelPath);
-    return session;
+    try {
+        await session.init(modelPath);
+        return session;
+    } catch (err) {
+        if (!isWebGpuFailure(err)) throw err;
+
+        // Best-effort reset onto CPU. `reset()` reuses the cached model bytes
+        // when present; if init() failed before caching them we fall through
+        // to a fresh init() with CPU EPs.
+        try {
+            await session.reset({ executionProviders: ['cpu'] });
+            return session;
+        } catch {
+            const cpuOnly = new Session();
+            await cpuOnly.init(modelPath, { executionProviders: ['cpu'] });
+            return cpuOnly;
+        }
+    }
 };
 
 export class SegmentAnythingModel {
@@ -43,29 +75,49 @@ export class SegmentAnythingModel {
         }
     }
 
-    public async processEncoder(initialImageData: ImageData): Promise<EncodingOutput> {
-        const session = this.sessions.get('encoder');
-
+    /**
+     * Invoke `op` against the given session. On a WebGPU / JSEP failure or a
+     * `SessionPoisonedError`, reset the session (downgrading to CPU EPs) and
+     * retry exactly once. The retry is the user-visible recovery path: the
+     * first call dies, the wrapper transparently recreates the session on the
+     * CPU EP, and the caller sees a successful (slower) result.
+     */
+    private async runWithRecovery<T>(
+        sessionKey: 'encoder' | 'decoder',
+        op: (session: Session) => Promise<T>
+    ): Promise<T> {
+        const session = this.sessions.get(sessionKey);
         if (!session) {
-            throw Error('the encoder is absent in the sessions map');
+            throw Error(`the ${sessionKey} is absent in the sessions map`);
         }
 
-        const encoder = new SegmentAnythingEncoder(this.cv, this.preProcessorConfig, session);
+        try {
+            return await op(session);
+        } catch (err) {
+            if (!isWebGpuFailure(err)) throw err;
 
-        return await encoder.processEncoder(initialImageData);
+            // Drop WebGPU on the retry — repeating the same EP after a JSEP
+            // crash will almost always fail the same way.
+            await session.reset({ executionProviders: ['cpu'] });
+            return await op(session);
+        }
+    }
+
+    public async processEncoder(initialImageData: ImageData): Promise<EncodingOutput> {
+        return this.runWithRecovery('encoder', (session) => {
+            const encoder = new SegmentAnythingEncoder(this.cv, this.preProcessorConfig, session);
+            return encoder.processEncoder(initialImageData);
+        });
     }
 
     public async processDecoder(
         encodingOutput: EncodingOutput,
         input: SegmentAnythingPrompt
     ): Promise<SegmentAnythingResult> {
-        const session = this.sessions.get('decoder');
-        if (!session) {
-            throw Error('the decoder is absent in the sessions map');
-        }
-
-        const decoder = new SegmentAnythingDecoder(this.cv, session);
-        const output = await decoder.process(encodingOutput, input);
+        const output = await this.runWithRecovery('decoder', (session) => {
+            const decoder = new SegmentAnythingDecoder(this.cv, session);
+            return decoder.process(encodingOutput, input);
+        });
 
         if (output.shapes.length === 0) {
             return {

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything.ts
@@ -51,17 +51,12 @@ const createSession = async (modelPath: string): Promise<Session> => {
 
 export class SegmentAnythingModel {
     private sessions = new Map<string, Session>();
-    private modelPaths: Map<string, string>;
-    private preProcessorConfig: OpenCVPreprocessorConfig;
 
     public constructor(
         private cv: cv,
-        modelPaths: Map<string, string>,
-        preProcessorConfig: OpenCVPreprocessorConfig
-    ) {
-        this.modelPaths = modelPaths;
-        this.preProcessorConfig = preProcessorConfig;
-    }
+        private modelPaths: Map<string, string>,
+        private preProcessorConfig: OpenCVPreprocessorConfig
+    ) {}
 
     public async init(algorithm: 'SEGMENT_ANYTHING_DECODER' | 'SEGMENT_ANYTHING_ENCODER'): Promise<void> {
         if (!this.sessions.has('encoder') && algorithm === 'SEGMENT_ANYTHING_ENCODER') {

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything.ts
@@ -17,8 +17,21 @@ const WEBGPU_ERROR_PATTERN = /webgpu|jsep|wasm|initwasm|no available backend/i;
 
 const isWebGpuFailure = (err: unknown): boolean => {
     if (err instanceof SessionPoisonedError) return true;
+
     const message = err instanceof Error ? err.message : String(err ?? '');
+
     return WEBGPU_ERROR_PATTERN.test(message);
+};
+
+/**
+ * Build a fresh Session pinned to the CPU EP. Used as the last-resort recovery
+ * path whenever an existing Session is too damaged to reset() (e.g.
+ * createOrtSession threw on the new EP, leaving `ortSession === undefined`).
+ */
+const createCpuSession = async (modelPath: string): Promise<Session> => {
+    const session = new Session();
+    await session.init(modelPath, { executionProviders: ['cpu'] });
+    return session;
 };
 
 /**
@@ -31,6 +44,7 @@ const createSession = async (modelPath: string): Promise<Session> => {
     const session = new Session();
     try {
         await session.init(modelPath);
+
         return session;
     } catch (err) {
         if (!isWebGpuFailure(err)) throw err;
@@ -40,11 +54,10 @@ const createSession = async (modelPath: string): Promise<Session> => {
         // to a fresh init() with CPU EPs.
         try {
             await session.reset({ executionProviders: ['cpu'] });
+
             return session;
         } catch {
-            const cpuOnly = new Session();
-            await cpuOnly.init(modelPath, { executionProviders: ['cpu'] });
-            return cpuOnly;
+            return createCpuSession(modelPath);
         }
     }
 };
@@ -93,7 +106,21 @@ export class SegmentAnythingModel {
 
             // Drop WebGPU on the retry — repeating the same EP after a JSEP
             // crash will almost always fail the same way.
-            await session.reset({ executionProviders: ['cpu'] });
+            try {
+                await session.reset({ executionProviders: ['cpu'] });
+            } catch {
+                // reset() failed (e.g. createOrtSession threw on the CPU EP).
+                // The Session is now wedged with `ortSession === undefined`,
+                // so every future run() would throw "session not initialized"
+                // for the rest of the page's lifetime. Replace the entry in
+                // the map with a fresh CPU-only Session so subsequent calls
+                // recover.
+                const replacement = await createCpuSession(this.modelPaths.get(sessionKey) ?? '');
+
+                this.sessions.set(sessionKey, replacement);
+
+                return await op(replacement);
+            }
             return await op(session);
         }
     }

--- a/web_ui/packages/smart-tools/src/segment-anything/segment-anything.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/segment-anything.ts
@@ -104,33 +104,27 @@ export class SegmentAnythingModel {
     }
 
     public async processEncoder(initialImageData: ImageData): Promise<EncodingOutput> {
-        return this.runWithRecovery('encoder', (session) => {
-            const encoder = new SegmentAnythingEncoder(this.cv, this.preProcessorConfig, session);
-            return encoder.processEncoder(initialImageData);
-        });
+        return this.runWithRecovery('encoder', (session) =>
+            new SegmentAnythingEncoder(this.cv, this.preProcessorConfig, session).processEncoder(initialImageData)
+        );
     }
 
     public async processDecoder(
         encodingOutput: EncodingOutput,
         input: SegmentAnythingPrompt
     ): Promise<SegmentAnythingResult> {
-        const output = await this.runWithRecovery('decoder', (session) => {
-            const decoder = new SegmentAnythingDecoder(this.cv, session);
-            return decoder.process(encodingOutput, input);
-        });
+        const { shapes, areas, maxContourIdx } = await this.runWithRecovery('decoder', (session) =>
+            new SegmentAnythingDecoder(this.cv, session).process(encodingOutput, input)
+        );
 
-        if (output.shapes.length === 0) {
-            return {
-                areas: [],
-                maxContourIdx: 0,
-                shapes: [],
-            };
+        if (shapes.length === 0) {
+            return { shapes: [], areas: [], maxContourIdx: 0 };
         }
 
         return {
-            areas: [output.areas[output.maxContourIdx]],
-            maxContourIdx: output.maxContourIdx,
-            shapes: [output.shapes[output.maxContourIdx]],
+            shapes: [shapes[maxContourIdx]],
+            areas: [areas[maxContourIdx]],
+            maxContourIdx,
         };
     }
 }

--- a/web_ui/packages/smart-tools/src/segment-anything/session.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/session.ts
@@ -12,13 +12,13 @@ const loadModel = async (modelPath: string) => {
 
 /**
  * Default per-call timeout (ms) applied when neither `init()` nor `run()`
- * specifies one. Chosen to be well above the 95p inference latency for the
- * SAM encoder/decoder on a slow CPU EP, while still bounding the worst case
- * so a hung `ortSession.run()` (e.g. JSEP/WebGPU stall) cannot block the
- * serial queue indefinitely. Override via `init({ runTimeoutMs })` or
- * `run({ timeoutMs })`; pass `0` to disable.
+ * specifies one. Sized to bound a hung `ortSession.run()` (e.g. JSEP/WebGPU
+ * stall, native deadlock) without false-firing on a legitimate slow SAM
+ * encoder pass on a CPU EP, which can comfortably take 30–60 s on modest
+ * hardware. Override via `init({ runTimeoutMs })` or `run({ timeoutMs })`;
+ * pass `0` to disable.
  */
-export const DEFAULT_RUN_TIMEOUT_MS = 30_000;
+export const DEFAULT_RUN_TIMEOUT_MS = 5 * 60_000;
 
 /**
  * Thrown when a single `Session.run()` call exceeds its configured timeout.

--- a/web_ui/packages/smart-tools/src/segment-anything/session.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/session.ts
@@ -11,6 +11,16 @@ const loadModel = async (modelPath: string) => {
 };
 
 /**
+ * Default per-call timeout (ms) applied when neither `init()` nor `run()`
+ * specifies one. Chosen to be well above the 95p inference latency for the
+ * SAM encoder/decoder on a slow CPU EP, while still bounding the worst case
+ * so a hung `ortSession.run()` (e.g. JSEP/WebGPU stall) cannot block the
+ * serial queue indefinitely. Override via `init({ runTimeoutMs })` or
+ * `run({ timeoutMs })`; pass `0` to disable.
+ */
+export const DEFAULT_RUN_TIMEOUT_MS = 30_000;
+
+/**
  * Thrown when a single `Session.run()` call exceeds its configured timeout.
  * The session is marked unhealthy after this — call `Session.reset()` to revive it.
  */
@@ -65,6 +75,11 @@ export class Session {
     private executionProviders: SessionParameters['executionProviders'];
     private runTimeoutMs: number | undefined;
     private poisoned = false;
+    // Bumped on every reset() and on poisoning. Captured by run() at enqueue
+    // time and re-checked inside the queued continuation so that calls already
+    // sitting behind a poisoned/replaced session are rejected instead of
+    // executing against a stale or corrupted ortSession.
+    private generation = 0;
 
     constructor() {
         this.params = sessionParams;
@@ -81,7 +96,10 @@ export class Session {
 
     public async init(modelPath: string, options?: SessionInitOptions): Promise<void> {
         this.executionProviders = options?.executionProviders ?? this.params.executionProviders;
-        this.runTimeoutMs = options?.runTimeoutMs;
+        // Default to a non-zero timeout so callers that omit `runTimeoutMs`
+        // are still protected from a hung run() blocking the serial queue.
+        // Explicit `0` disables the timeout.
+        this.runTimeoutMs = options?.runTimeoutMs ?? DEFAULT_RUN_TIMEOUT_MS;
 
         const modelData = await loadModel(modelPath);
 
@@ -126,8 +144,12 @@ export class Session {
             }
         }
 
-        // Drop any chained-but-never-resolved tail (e.g. a hung run()).
+        // Drop any chained-but-never-resolved tail (e.g. a hung run()) and
+        // invalidate any run() calls that are already queued — they captured
+        // the previous generation and must not execute against the new
+        // session.
         this.pending = Promise.resolve();
+        this.generation++;
         this.poisoned = false;
 
         await this.createOrtSession();
@@ -156,8 +178,7 @@ export class Session {
         input: InferenceSession.OnnxValueMapType,
         options?: SessionRunOptions
     ): Promise<InferenceSession.OnnxValueMapType> {
-        const session = this.ortSession;
-        if (!session) {
+        if (!this.ortSession) {
             throw Error('the session is not initialized. Call `init()` method first.');
         }
         if (this.poisoned) {
@@ -165,10 +186,28 @@ export class Session {
         }
 
         const timeoutMs = options?.timeoutMs ?? this.runTimeoutMs;
+        // Snapshot the session generation at enqueue time. If poisoning or a
+        // reset() bumps it before our turn arrives, we must refuse to run
+        // against the stale/corrupted (or now-replaced) ortSession.
+        const enqueuedGeneration = this.generation;
 
         // Wait for our turn but never propagate a previous failure to this call.
         const waitForTurn = this.pending.catch(() => undefined);
-        const next = waitForTurn.then(() => this.runOnce(session, input, timeoutMs));
+        const next = waitForTurn.then(() => {
+            // Re-validate just before invoking ortSession.run(): an earlier
+            // queued call may have poisoned the session, or reset() may have
+            // replaced it entirely while we were waiting.
+            if (this.poisoned || this.generation !== enqueuedGeneration) {
+                throw new SessionPoisonedError();
+            }
+
+            const currentSession = this.ortSession;
+            if (!currentSession) {
+                throw new SessionPoisonedError();
+            }
+
+            return this.runOnce(currentSession, input, timeoutMs);
+        });
 
         // Always advance the queue, regardless of whether `next` resolves or
         // rejects (incl. timeout). Without `.catch(...)` here a hung run()
@@ -191,7 +230,7 @@ export class Session {
                 // Any thrown error from ortSession.run() is treated as
                 // unrecoverable — JSEP failures leave the WASM heap in an
                 // inconsistent state and subsequent runs OOB or return garbage.
-                this.poisoned = true;
+                this.poison();
                 throw err;
             });
         }
@@ -199,7 +238,7 @@ export class Session {
         let timer: ReturnType<typeof setTimeout> | undefined;
         const timeoutPromise = new Promise<never>((_, reject) => {
             timer = setTimeout(() => {
-                this.poisoned = true;
+                this.poison();
                 reject(new SessionRunTimeoutError(timeoutMs));
             }, timeoutMs);
         });
@@ -211,10 +250,19 @@ export class Session {
             },
             (err) => {
                 if (timer !== undefined) clearTimeout(timer);
-                this.poisoned = true;
+                this.poison();
                 throw err;
             }
         );
+    }
+
+    private poison(): void {
+        if (this.poisoned) return;
+        this.poisoned = true;
+        // Bump the generation so any run() calls already queued behind this
+        // one are rejected in their `then(...)` re-check instead of executing
+        // against the now-corrupted session.
+        this.generation++;
     }
 
     public inputNames(): readonly string[] {

--- a/web_ui/packages/smart-tools/src/segment-anything/session.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/session.ts
@@ -10,22 +10,78 @@ const loadModel = async (modelPath: string) => {
     return await (await loadSource(modelPath))?.arrayBuffer();
 };
 
+/**
+ * Thrown when a single `Session.run()` call exceeds its configured timeout.
+ * The session is marked unhealthy after this — call `Session.reset()` to revive it.
+ */
+export class SessionRunTimeoutError extends Error {
+    constructor(timeoutMs: number) {
+        super(`ortSession.run() did not complete within ${timeoutMs}ms`);
+        this.name = 'SessionRunTimeoutError';
+    }
+}
+
+/**
+ * Thrown by `Session.run()` when a previous call left the underlying
+ * InferenceSession in an unrecoverable state (WASM heap corruption, EP stall, ...).
+ * The caller should call `Session.reset()` (optionally downgrading the EP) before
+ * issuing more runs.
+ */
+export class SessionPoisonedError extends Error {
+    constructor() {
+        super('Session is poisoned after a previous unrecoverable failure. Call Session.reset() to revive it.');
+        this.name = 'SessionPoisonedError';
+    }
+}
+
+export interface SessionInitOptions {
+    /**
+     * Override the default execution providers (e.g. `['cpu']` to force CPU on
+     * platforms where WebGPU is unavailable or broken).
+     */
+    executionProviders?: SessionParameters['executionProviders'];
+    /**
+     * Default timeout (ms) applied to every `run()` call unless overridden per-call.
+     * `0` or `undefined` disables the timeout.
+     */
+    runTimeoutMs?: number;
+}
+
+export interface SessionRunOptions {
+    /** Per-call timeout (ms) overriding the session-level default. */
+    timeoutMs?: number;
+}
+
 export class Session {
     ortSession: InferenceSession | undefined;
     params: SessionParameters;
-    private runQueue: Promise<void> = Promise.resolve();
+    // Tail of the serial run() queue. onnxruntime-web doesn't support
+    // concurrent run() calls on the same session, so each run waits for
+    // the previous one. `unknown` lets us chain without type-juggling.
+    private pending: Promise<unknown> = Promise.resolve();
+    // Cached model bytes so reset() can recreate the InferenceSession without
+    // re-downloading. Kept until the Session is discarded.
+    private modelData: ArrayBuffer | undefined;
+    private executionProviders: SessionParameters['executionProviders'];
+    private runTimeoutMs: number | undefined;
+    private poisoned = false;
 
     constructor() {
         this.params = sessionParams;
+        this.executionProviders = sessionParams.executionProviders;
     }
 
-    public async init(modelPath: string) {
-        env.wasm.numThreads = this.params.numThreads;
-        env.wasm.wasmPaths = this.params.wasmRoot;
-        env.wasm.simd = true;
-        // Suppress expected "some nodes not assigned to WebGPU EP" warnings —
-        // ORT intentionally keeps shape-related ops on CPU for performance.
-        env.logLevel = 'error';
+    /**
+     * `true` while the underlying ortSession is created and no unrecoverable
+     * failure (thrown error or timeout) has been observed since.
+     */
+    public get isHealthy(): boolean {
+        return !this.poisoned && this.ortSession !== undefined;
+    }
+
+    public async init(modelPath: string, options?: SessionInitOptions): Promise<void> {
+        this.executionProviders = options?.executionProviders ?? this.params.executionProviders;
+        this.runTimeoutMs = options?.runTimeoutMs;
 
         const modelData = await loadModel(modelPath);
 
@@ -33,8 +89,60 @@ export class Session {
             throw new Error(`Unable to load model from "${modelPath}"`);
         }
 
-        const session = await InferenceSession.create(modelData, {
-            executionProviders: this.params.executionProviders,
+        this.modelData = modelData;
+        await this.createOrtSession();
+    }
+
+    /**
+     * Recreate the underlying InferenceSession from the cached model bytes,
+     * after a poisoning failure (WASM OOB, JSEP kernel crash, EP hang, ...).
+     * Reuses the model bytes captured during `init()` — no re-download.
+     *
+     * Pass `executionProviders` to downgrade after repeated WebGPU failures
+     * (e.g. `{ executionProviders: ['cpu'] }`). Without it the previously
+     * configured EPs are reused.
+     */
+    public async reset(options?: SessionInitOptions): Promise<void> {
+        if (!this.modelData) {
+            throw new Error('Session.reset() called before init(); no model bytes cached.');
+        }
+
+        if (options?.executionProviders) {
+            this.executionProviders = options.executionProviders;
+        }
+        if (options?.runTimeoutMs !== undefined) {
+            this.runTimeoutMs = options.runTimeoutMs;
+        }
+
+        // Best-effort release of the dead session — the WASM heap may already
+        // be corrupt, so swallow any error from release().
+        const previous = this.ortSession;
+        this.ortSession = undefined;
+        if (previous && typeof previous.release === 'function') {
+            try {
+                await previous.release();
+            } catch {
+                // ignore — session is going away anyway
+            }
+        }
+
+        // Drop any chained-but-never-resolved tail (e.g. a hung run()).
+        this.pending = Promise.resolve();
+        this.poisoned = false;
+
+        await this.createOrtSession();
+    }
+
+    private async createOrtSession(): Promise<void> {
+        env.wasm.numThreads = this.params.numThreads;
+        env.wasm.wasmPaths = this.params.wasmRoot;
+        env.wasm.simd = true;
+        // Suppress expected "some nodes not assigned to WebGPU EP" warnings —
+        // ORT intentionally keeps shape-related ops on CPU for performance.
+        env.logLevel = 'error';
+
+        this.ortSession = await InferenceSession.create(this.modelData as ArrayBuffer, {
+            executionProviders: this.executionProviders,
             graphOptimizationLevel: 'all',
             executionMode: 'parallel',
             // 0=verbose, 1=info, 2=warning, 3=error, 4=fatal. Silences the
@@ -42,22 +150,71 @@ export class Session {
             // ORT intentionally keeps shape-related ops on the CPU EP.
             logSeverityLevel: 3,
         });
-
-        this.ortSession = session;
     }
 
-    public async run(input: InferenceSession.OnnxValueMapType): Promise<InferenceSession.OnnxValueMapType> {
-        if (!this.ortSession) {
+    public async run(
+        input: InferenceSession.OnnxValueMapType,
+        options?: SessionRunOptions
+    ): Promise<InferenceSession.OnnxValueMapType> {
+        const session = this.ortSession;
+        if (!session) {
             throw Error('the session is not initialized. Call `init()` method first.');
         }
-        // onnxruntime-web does not support concurrent run() calls on the same session.
-        // Serialize calls through a void queue so the result type stays clean.
-        const runNext = this.runQueue.then(() => this.ortSession!.run(input));
-        this.runQueue = runNext.then(
-            () => undefined,
-            () => undefined
+        if (this.poisoned) {
+            throw new SessionPoisonedError();
+        }
+
+        const timeoutMs = options?.timeoutMs ?? this.runTimeoutMs;
+
+        // Wait for our turn but never propagate a previous failure to this call.
+        const waitForTurn = this.pending.catch(() => undefined);
+        const next = waitForTurn.then(() => this.runOnce(session, input, timeoutMs));
+
+        // Always advance the queue, regardless of whether `next` resolves or
+        // rejects (incl. timeout). Without `.catch(...)` here a hung run()
+        // would leave every subsequent caller chained behind a never-settling
+        // promise.
+        this.pending = next.catch(() => undefined);
+
+        return next;
+    }
+
+    private runOnce(
+        session: InferenceSession,
+        input: InferenceSession.OnnxValueMapType,
+        timeoutMs: number | undefined
+    ): Promise<InferenceSession.OnnxValueMapType> {
+        const runPromise = session.run(input);
+
+        if (!timeoutMs || timeoutMs <= 0) {
+            return runPromise.catch((err) => {
+                // Any thrown error from ortSession.run() is treated as
+                // unrecoverable — JSEP failures leave the WASM heap in an
+                // inconsistent state and subsequent runs OOB or return garbage.
+                this.poisoned = true;
+                throw err;
+            });
+        }
+
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+            timer = setTimeout(() => {
+                this.poisoned = true;
+                reject(new SessionRunTimeoutError(timeoutMs));
+            }, timeoutMs);
+        });
+
+        return Promise.race([runPromise, timeoutPromise]).then(
+            (result) => {
+                if (timer !== undefined) clearTimeout(timer);
+                return result;
+            },
+            (err) => {
+                if (timer !== undefined) clearTimeout(timer);
+                this.poisoned = true;
+                throw err;
+            }
         );
-        return runNext;
     }
 
     public inputNames(): readonly string[] {

--- a/web_ui/packages/smart-tools/src/segment-anything/session.ts
+++ b/web_ui/packages/smart-tools/src/segment-anything/session.ts
@@ -156,7 +156,14 @@ export class Session {
     }
 
     private async createOrtSession(): Promise<void> {
-        env.wasm.numThreads = this.params.numThreads;
+        // The threaded JSEP wasm needs SharedArrayBuffer / cross-origin
+        // isolation. When we're running CPU-only (either by config or after
+        // a WebGPU/JSEP downgrade) force single-threaded wasm so ORT skips
+        // pthread_create entirely — once `initWasm()` fails it stays failed
+        // for the lifetime of the page and even pure-CPU sessions reject
+        // with "previous call to 'initWasm()' failed".
+        const cpuOnly = this.executionProviders.length === 1 && this.executionProviders[0] === 'cpu';
+        env.wasm.numThreads = cpuOnly ? 1 : this.params.numThreads;
         env.wasm.wasmPaths = this.params.wasmRoot;
         env.wasm.simd = true;
         // Suppress expected "some nodes not assigned to WebGPU EP" warnings —

--- a/web_ui/packages/smart-tools/src/utils/tool-utils.ts
+++ b/web_ui/packages/smart-tools/src/utils/tool-utils.ts
@@ -128,12 +128,13 @@ export const loadSource = async (source: string, cacheKey = 'general'): Promise<
 
     const response = await self.fetch(source);
 
-    // Putting the model in cache might fail if the user does not have enough storage
-    try {
-        await cache.put(source, response.clone());
-    } finally {
-        return response;
-    }
+    // Fire-and-forget: awaiting cache.put can stall for tens of seconds on
+    // WebKit / busy Chromium profiles, blocking the model load even though the
+    // bytes are already in hand. Failures (e.g. quota exceeded) are silently
+    // ignored — caching is a best-effort optimisation.
+    void cache.put(source, response.clone()).catch(() => undefined);
+
+    return response;
 };
 
 export const getPointsFromMat = (mat: OpenCVTypes.Mat, offset = { x: 0, y: 0 }): Point[] => {

--- a/web_ui/packages/smart-tools/src/utils/wasm-utils.ts
+++ b/web_ui/packages/smart-tools/src/utils/wasm-utils.ts
@@ -14,8 +14,37 @@ const wasmPaths = {
     ).toString(),
 };
 
+/**
+ * The threaded JSEP wasm needs `SharedArrayBuffer`, which in turn needs
+ * cross-origin isolation (COOP/COEP). Tauri's WebView and any non-isolated
+ * browser context don't satisfy that, so `pthread_create` fails when ORT
+ * tries to spin up its worker pool. Once `initWasm()` fails ORT caches the
+ * failure globally and even the CPU EP fallback rejects with
+ * "previous call to 'initWasm()' failed".
+ *
+ * Detect that environment up front: force single-threaded wasm and drop the
+ * `webgpu` EP (its kernels require the threaded wasm). Browsers with proper
+ * isolation keep the multi-threaded WebGPU path.
+ */
+const hasThreadedWasmSupport = (): boolean => {
+    try {
+        return (
+            typeof SharedArrayBuffer !== 'undefined' &&
+            typeof globalThis !== 'undefined' &&
+            // `crossOriginIsolated` is the canonical signal; absent in Tauri WebView.
+            (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated === true
+        );
+    } catch {
+        return false;
+    }
+};
+
+const threaded = hasThreadedWasmSupport();
+
 export const sessionParams: SessionParameters = {
-    numThreads: 0,
-    executionProviders: ['webgpu', 'cpu'],
+    // `0` lets ORT pick `navigator.hardwareConcurrency`. Force `1` when we
+    // can't spawn workers so ORT skips pthread_create entirely.
+    numThreads: threaded ? 0 : 1,
+    executionProviders: threaded ? ['webgpu', 'cpu'] : ['cpu'],
     wasmRoot: wasmPaths,
 };

--- a/web_ui/src/hooks/use-load-ai-webworker/load-webworker.interface.ts
+++ b/web_ui/src/hooks/use-load-ai-webworker/load-webworker.interface.ts
@@ -3,7 +3,7 @@
 
 import { Grabcut, InferenceImage, IntelligentScissors, SSIM, Watershed } from '@geti/smart-tools';
 import { RITM } from '@geti/smart-tools/ritm';
-import { SegmentAnythingModel } from '@geti/smart-tools/segment-anything';
+import { SegmentAnythingModelWrapper } from '@geti/smart-tools/segment-anything';
 import { Remote } from 'comlink';
 
 import { AlgorithmType } from './algorithm.interface';
@@ -19,6 +19,6 @@ export type MapAlgorithmToInstance = {
     [AlgorithmType.RITM]: RITM;
     [AlgorithmType.SSIM]: SSIM;
     [AlgorithmType.INFERENCE_IMAGE]: InferenceImage;
-    [AlgorithmType.SEGMENT_ANYTHING_ENCODER]: SegmentAnythingModel;
-    [AlgorithmType.SEGMENT_ANYTHING_DECODER]: SegmentAnythingModel;
+    [AlgorithmType.SEGMENT_ANYTHING_ENCODER]: SegmentAnythingModelWrapper;
+    [AlgorithmType.SEGMENT_ANYTHING_DECODER]: SegmentAnythingModelWrapper;
 };

--- a/web_ui/src/pages/annotator/tools/segment-anything-tool/use-segment-anything-model.hook.ts
+++ b/web_ui/src/pages/annotator/tools/segment-anything-tool/use-segment-anything-model.hook.ts
@@ -56,10 +56,9 @@ const useDecodingFn = (model: Remote<SegmentAnythingModel> | undefined, encoding
         const { shapes } = await model.processDecoder(encoding, {
             points,
             boxes: [],
-            ouputConfig: {
+            outputConfig: {
                 type: shapeType,
             },
-            image: undefined,
         });
 
         return shapes.map(convertToolShapeToGetiShape);
@@ -84,7 +83,7 @@ const useEncodingQuery = (
             return await model.processEncoder(selectedMediaItem.image);
         },
         staleTime: Infinity,
-        gcTime: 3600 * 15, // WIP
+        gcTime: Infinity,
         enabled: model !== undefined && selectedMediaItem !== undefined,
     });
 };
@@ -101,15 +100,19 @@ const useSegmentAnythingWorker = (
         const loadWorker = async () => {
             setModelIsLoading(true);
 
-            if (worker) {
-                const model = worker;
+            try {
+                if (worker) {
+                    const model = worker;
 
-                await model.init(algorithmType);
+                    await model.init(algorithmType);
 
-                modelRef.current = model;
+                    modelRef.current = model;
+                }
+            } catch (err) {
+                console.error('[SAM] Failed to initialize worker', err);
+            } finally {
+                setModelIsLoading(false);
             }
-
-            setModelIsLoading(false);
         };
 
         if (worker && modelRef.current === undefined && !modelIsLoading) {


### PR DESCRIPTION
## 📝 Description

Issues addressed:

* Browser (Chrome): intermittent JSEP Resize kernel failures → WASM heap corruption → every subsequent ortSession.run() returns garbage.
* Tauri (WebView2 / WKWebView): ortSession.run() occasionally hangs forever (WebGPU / memory related). The serial runQueue chained every later call onto the never-settling promise, blocking the session indefinitely.
* Random issue we had before on chrome that the worker was forever loading (dont await for cache.put)
* Cleanup/simplification

Manually tested Geti Tune browser and tauri app (by updating the hash of the packages that 'tiged' uses)

## ✨ Type of Change

Select the type of change your PR introduces:

- [ ] 🐞 **Bug fix** – Non-breaking change which fixes an issue
- [ ] 🚀 **New feature** – Non-breaking change which adds functionality
- [ ] 🔨 **Refactor** – Non-breaking change which refactors the code base
- [ ] 💥 **Breaking change** – Changes that break existing functionality
- [ ] 📚 **Documentation update**
- [ ] 🔒 **Security update**
- [ ] 🧪 **Tests**

## 🧪 Testing Scenarios

Describe how the changes were tested and how reviewers can test them too:

- [x] ✅ Tested manually
- [ ] 🤖 Run automated end-to-end tests


## ✅ Checklist

Before submitting the PR, ensure the following:

- [ ] 🔍 PR title is clear and meaningful
- [ ] ✍️ PR description clearly explains the changes and their reason
- [ ] 📝 I have linked the PR to the corresponding GitHub Issues, if any
- [ ] 💬 I have commented my code, especially in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ✅ I have added tests that prove my fix is effective or my feature works
